### PR TITLE
upgrade mssql version to 12.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target
 *.code-workspace
 .bloop
 .metals
+dumps

--- a/core/src/test/resources/sqlserver-application.conf
+++ b/core/src/test/resources/sqlserver-application.conf
@@ -66,7 +66,7 @@ slick {
   db {
     host = ${docker.host}
     host = ${?DB_HOST}
-    url = "jdbc:sqlserver://"${slick.db.host}":1433;databaseName=docker;integratedSecurity=false"
+    url = "jdbc:sqlserver://"${slick.db.host}":1433;databaseName=docker;integratedSecurity=false;encrypt=false;"
     user = "docker"
     password = "docker"
     driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"

--- a/core/src/test/resources/sqlserver-shared-db-application.conf
+++ b/core/src/test/resources/sqlserver-shared-db-application.conf
@@ -36,7 +36,7 @@ pekko-persistence-jdbc {
       db {
         host = ${docker.host}
         host = ${?DB_HOST}
-        url = "jdbc:sqlserver://"${pekko-persistence-jdbc.shared-databases.slick.db.host}":1433;databaseName=docker;integratedSecurity=false;"
+        url = "jdbc:sqlserver://"${pekko-persistence-jdbc.shared-databases.slick.db.host}":1433;databaseName=docker;integratedSecurity=false;encrypt=false;"
         user = "docker"
         password = "docker"
         driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"

--- a/migrator/src/test/resources/sqlserver-application.conf
+++ b/migrator/src/test/resources/sqlserver-application.conf
@@ -56,7 +56,7 @@ slick {
   db {
     host = ${docker.host}
     host = ${?DB_HOST}
-    url = "jdbc:sqlserver://"${slick.db.host}":1433;databaseName=docker;integratedSecurity=false;encrypt=false"
+    url = "jdbc:sqlserver://"${slick.db.host}":1433;databaseName=docker;integratedSecurity=false;encrypt=false;"
     user = "docker"
     password = "docker"
     driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"

--- a/migrator/src/test/resources/sqlserver-application.conf
+++ b/migrator/src/test/resources/sqlserver-application.conf
@@ -56,7 +56,7 @@ slick {
   db {
     host = ${docker.host}
     host = ${?DB_HOST}
-    url = "jdbc:sqlserver://"${slick.db.host}":1433;databaseName=docker;integratedSecurity=false"
+    url = "jdbc:sqlserver://"${slick.db.host}":1433;databaseName=docker;integratedSecurity=false;encrypt=false"
     user = "docker"
     password = "docker"
     driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
     "org.postgresql" % "postgresql" % "42.7.3",
     "com.h2database" % "h2" % "2.2.224",
     "com.mysql" % "mysql-connector-j" % "8.3.0",
-    "com.microsoft.sqlserver" % "mssql-jdbc" % "8.4.1.jre8",
+    "com.microsoft.sqlserver" % "mssql-jdbc" % "12.6.1.jre8",
     "com.oracle.database.jdbc" % "ojdbc6" % "11.2.0.4")
 
   val Libraries: Seq[ModuleID] = Seq(


### PR DESCRIPTION
close #113 

I search the changes in mssql release
https://github.com/microsoft/mssql-jdbc/releases?q=encrypt&expanded=true
look at this picture. 
![image](https://github.com/apache/pekko-projection/assets/35491928/3e693b8c-7de8-4fec-a239-da6a2e700634)

## How to solve this for our test
(1) add `encrypt=true;trustServerCertificate=true"` to jdbc url
(2) or add `encrypt=false` to jdbc url
## What can users do?
users should ensure that the sqlserver enable tls,maybe need some config, so that client can connect to sqlserver with TLS