### PR TITLE
perf: improve journal deletion

### DIFF
--- a/core/src/main/mima-filters/1.1.x.backwards.excludes/BaseDao.excludes
+++ b/core/src/main/mima-filters/1.1.x.backwards.excludes/BaseDao.excludes
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.journal.dao.BaseDao.writeQueue")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.BaseDao.writeQueue")

--- a/core/src/main/mima-filters/1.1.x.backwards.excludes/deletion-optimize.excludes
+++ b/core/src/main/mima-filters/1.1.x.backwards.excludes/deletion-optimize.excludes
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.markJournalMessagesAsDeleted")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.JournalQueries.markJournalMessagesAsDeleted")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.highestMarkedSequenceNrForPersistenceId")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.JournalQueries.highestMarkedSequenceNrForPersistenceId")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.selectByPersistenceIdAndMaxSequenceNumber")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.JournalQueries.selectByPersistenceIdAndMaxSequenceNumber")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.allPersistenceIdsDistinct")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.JournalQueries.allPersistenceIdsDistinct")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.journalRowByPersistenceIds")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.JournalQueries.journalRowByPersistenceIds")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.query.dao.ReadJournalQueries.journalRowByPersistenceIds")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.query.dao.legacy.ReadJournalQueries.journalRowByPersistenceIds")

--- a/core/src/main/mima-filters/1.1.x.backwards.excludes/deletion-optimize.excludes
+++ b/core/src/main/mima-filters/1.1.x.backwards.excludes/deletion-optimize.excludes
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.markJournalMessagesAsDeleted")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.JournalQueries.markJournalMessagesAsDeleted")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.highestMarkedSequenceNrForPersistenceId")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.JournalQueries.highestMarkedSequenceNrForPersistenceId")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.selectByPersistenceIdAndMaxSequenceNumber")

--- a/core/src/main/mima-filters/1.1.x.backwards.excludes/deletion-optimize.excludes
+++ b/core/src/main/mima-filters/1.1.x.backwards.excludes/deletion-optimize.excludes
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.markJournalMessagesAsDeleted")
-ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.JournalQueries.markJournalMessagesAsDeleted")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.highestMarkedSequenceNrForPersistenceId")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.JournalQueries.highestMarkedSequenceNrForPersistenceId")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.JournalQueries.selectByPersistenceIdAndMaxSequenceNumber")

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
@@ -59,7 +59,9 @@ class DefaultJournalDao(
     new JournalQueries(profile, journalConfig.eventJournalTableConfiguration, journalConfig.eventTagTableConfiguration)
 
   override def delete(persistenceId: String, maxSequenceNr: Long): Future[Unit] = {
-    db.run(queries.delete(persistenceId, maxSequenceNr)).map(_ => ())
+    // We should keep journal record with highest sequence number in order to be compliant
+    // with @see [[pekko.persistence.journal.JournalSpec]]
+    db.run(queries.delete(persistenceId, maxSequenceNr - 1)).map(_ => ())
   }
 
   override def highestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] = {

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
@@ -59,9 +59,12 @@ class DefaultJournalDao(
     new JournalQueries(profile, journalConfig.eventJournalTableConfiguration, journalConfig.eventTagTableConfiguration)
 
   override def delete(persistenceId: String, maxSequenceNr: Long): Future[Unit] = {
+    // We should keep journal record with highest sequence number in order to be compliant
+    // with @see [[pekko.persistence.journal.JournalSpec]]
     val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
-      _ <- queries.delete(persistenceId, maxSequenceNr - 1)
-      _ <- queries.markMaxSequenceNrJournalMessagesAsDeleted(persistenceId, maxSequenceNr)
+      highestSequenceNr <- queries.beforeHighestSequenceNrForPersistenceId(persistenceId, maxSequenceNr).result
+      _ <- queries.delete(persistenceId, highestSequenceNr - 1)
+      _ <- queries.markMaxSequenceNrJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
     } yield ()
 
     db.run(actions.transactionally)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
@@ -62,7 +62,7 @@ class DefaultJournalDao(
     // We should keep journal record with highest sequence number in order to be compliant
     // with @see [[pekko.persistence.journal.JournalSpec]]
     val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
-      highestSequenceNr <- queries.beforeHighestSequenceNrForPersistenceId(persistenceId, maxSequenceNr).result
+      highestSequenceNr <- queries.beforeHighestSequenceNrForPersistenceId((persistenceId, maxSequenceNr)).result
       _ <- queries.delete(persistenceId, highestSequenceNr - 1)
       _ <- queries.markMaxSequenceNrJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
     } yield ()

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
@@ -59,7 +59,7 @@ class DefaultJournalDao(
     new JournalQueries(profile, journalConfig.eventJournalTableConfiguration, journalConfig.eventTagTableConfiguration)
 
   override def delete(persistenceId: String, maxSequenceNr: Long): Future[Unit] = {
-    db.run(queries.delete(persistenceId, maxSequenceNr - 1)).map(_ => ())
+    db.run(queries.delete(persistenceId, maxSequenceNr)).map(_ => ())
   }
 
   override def highestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] = {

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
@@ -62,7 +62,8 @@ class DefaultJournalDao(
     // We should keep journal record with highest sequence number in order to be compliant
     // with @see [[pekko.persistence.journal.JournalSpec]]
     val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
-      highestSequenceNr <- queries.highestSequenceNrForPersistenceIdBefore((persistenceId, maxSequenceNr)).result
+      seq <- queries.highestSequenceNrForPersistenceIdBefore((persistenceId, maxSequenceNr)).result
+      highestSequenceNr = seq.headOption.getOrElse(0L)
       _ <- queries.delete(persistenceId, highestSequenceNr - 1)
       _ <- queries.markSeqNrJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
     } yield ()

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
@@ -64,7 +64,7 @@ class DefaultJournalDao(
     val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
       highestSequenceNr <- queries.highestSequenceNrForPersistenceIdBefore((persistenceId, maxSequenceNr)).result
       _ <- queries.delete(persistenceId, highestSequenceNr - 1)
-      _ <- queries.markJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
+      _ <- queries.markSeqNrJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
     } yield ()
 
     db.run(actions.transactionally)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
@@ -59,9 +59,12 @@ class DefaultJournalDao(
     new JournalQueries(profile, journalConfig.eventJournalTableConfiguration, journalConfig.eventTagTableConfiguration)
 
   override def delete(persistenceId: String, maxSequenceNr: Long): Future[Unit] = {
-    // We should keep journal record with highest sequence number in order to be compliant
-    // with @see [[pekko.persistence.journal.JournalSpec]]
-    db.run(queries.delete(persistenceId, maxSequenceNr - 1)).map(_ => ())
+    val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
+      _ <- queries.delete(persistenceId, maxSequenceNr - 1)
+      _ <- queries.markMaxSequenceNrJournalMessagesAsDeleted(persistenceId, maxSequenceNr)
+    } yield ()
+
+    db.run(actions.transactionally)
   }
 
   override def highestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] = {

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
@@ -62,9 +62,9 @@ class DefaultJournalDao(
     // We should keep journal record with highest sequence number in order to be compliant
     // with @see [[pekko.persistence.journal.JournalSpec]]
     val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
-      highestSequenceNr <- queries.beforeHighestSequenceNrForPersistenceId((persistenceId, maxSequenceNr)).result
+      highestSequenceNr <- queries.highestSequenceNrForPersistenceIdBefore((persistenceId, maxSequenceNr)).result
       _ <- queries.delete(persistenceId, highestSequenceNr - 1)
-      _ <- queries.markMaxSequenceNrJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
+      _ <- queries.markJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
     } yield ()
 
     db.run(actions.transactionally)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -51,11 +51,19 @@ class JournalQueries(
   }
 
   def delete(persistenceId: String, toSequenceNr: Long) = {
-    JournalTable.filter(_.persistenceId === persistenceId).filter(_.sequenceNumber <= toSequenceNr).delete
+    JournalTable
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.sequenceNumber <= toSequenceNr)
+      .delete
   }
 
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
-    JournalTable.filter(_.persistenceId === persistenceId).take(1).map(_.sequenceNumber).max
+    JournalTable
+      .filter(_.persistenceId === persistenceId)
+      .sortBy(_.sequenceNumber.desc)
+      .take(1)
+      .map(_.sequenceNumber)
+      .max
 
   val highestSequenceNrForPersistenceId = Compiled(_highestSequenceNrForPersistenceId _)
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -62,6 +62,7 @@ class JournalQueries(
 
   private def _selectByPersistenceIdAndMaxSequenceNr(persistenceId: Rep[String], maxSeqNr: Rep[Long]) =
     _selectByPersistenceId(persistenceId).filter(_.sequenceNumber <= maxSeqNr)
+
   val selectByPersistenceIdAndMaxSequenceNr = Compiled(_selectByPersistenceIdAndMaxSequenceNr _)
 
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -57,6 +57,14 @@ class JournalQueries(
       .delete
   }
 
+  def markMaxSequenceNrJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long) =
+    JournalTable
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.sequenceNumber == maxSequenceNr)
+      .filter(_.deleted === false)
+      .map(_.deleted)
+      .update(true)
+
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
     JournalTable
       .filter(_.persistenceId === persistenceId)
@@ -74,6 +82,7 @@ class JournalQueries(
       max: ConstColumn[Long]) =
     JournalTable
       .filter(_.persistenceId === persistenceId)
+      .filter(_.deleted === false)
       .filter(_.sequenceNumber >= fromSequenceNr)
       .filter(_.sequenceNumber <= toSequenceNr) // TODO optimized this avoid large offset query.
       .sortBy(_.sequenceNumber.asc)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -74,13 +74,11 @@ class JournalQueries(
 
   private def _highestSequenceNrForPersistenceIdBefore(
       persistenceId: Rep[String],
-      maxSequenceNr: Rep[Long]): Rep[Long] =
+      maxSequenceNr: Rep[Long]): Query[Rep[Long], Long, Seq] =
     selectAllJournalForPersistenceId(persistenceId)
       .filter(_.sequenceNumber <= maxSequenceNr)
-      .take(1)
       .map(_.sequenceNumber)
-      .max
-      .getOrElse(0L)
+      .take(1)
 
   private def _messagesQuery(
       persistenceId: Rep[String],

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -61,10 +61,10 @@ class JournalQueries(
     JournalTable.filter(_.persistenceId === persistenceId).filter(_.sequenceNumber <= toSequenceNr).delete
   }
 
-  def markJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long) =
+  def markSeqNrJournalMessagesAsDeleted(persistenceId: String, sequenceNr: Long) =
     JournalTable
       .filter(_.persistenceId === persistenceId)
-      .filter(_.sequenceNumber === maxSequenceNr)
+      .filter(_.sequenceNumber === sequenceNr)
       .filter(_.deleted === false)
       .map(_.deleted)
       .update(true)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -51,7 +51,7 @@ class JournalQueries(
   }
 
   def delete(persistenceId: String, toSequenceNr: Long) = {
-    selectByPersistenceIdAndSequenceNr(persistenceId, toSequenceNr).delete
+    selectByPersistenceIdAndMaxSequenceNr(persistenceId, toSequenceNr).delete
   }
 
   private def _selectAllJournalForPersistenceId(persistenceId: Rep[String]) =
@@ -62,7 +62,7 @@ class JournalQueries(
 
   private def _selectByPersistenceIdAndMaxSequenceNr(persistenceId: Rep[String], maxSeqNr: Rep[Long]) =
     _selectByPersistenceId(persistenceId).filter(_.sequenceNumber <= maxSeqNr)
-  val selectByPersistenceIdAndSequenceNr = Compiled(_selectByPersistenceIdAndMaxSequenceNr _)
+  val selectByPersistenceIdAndMaxSequenceNr = Compiled(_selectByPersistenceIdAndMaxSequenceNr _)
 
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
     _selectAllJournalForPersistenceId(persistenceId).take(1).map(_.sequenceNumber).max

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -60,7 +60,7 @@ class JournalQueries(
   def markMaxSequenceNrJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long) =
     JournalTable
       .filter(_.persistenceId === persistenceId)
-      .filter(_.sequenceNumber == maxSequenceNr)
+      .filter(_.sequenceNumber === maxSequenceNr)
       .filter(_.deleted === false)
       .map(_.deleted)
       .update(true)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -51,29 +51,13 @@ class JournalQueries(
   }
 
   def delete(persistenceId: String, toSequenceNr: Long) = {
-    selectByPersistenceIdAndMaxSequenceNr(persistenceId, toSequenceNr).delete
+    JournalTable.filter(_.persistenceId === persistenceId).filter(_.sequenceNumber <= toSequenceNr).delete
   }
 
-  private def _selectAllJournalForPersistenceId(persistenceId: Rep[String]) =
-    _selectByPersistenceId(persistenceId).sortBy(_.sequenceNumber.desc)
-
-  private def _selectByPersistenceId(persistenceId: Rep[String]) =
-    JournalTable.filter(_.persistenceId === persistenceId)
-
-  private def _selectByPersistenceIdAndMaxSequenceNr(persistenceId: Rep[String], maxSeqNr: Rep[Long]) =
-    _selectByPersistenceId(persistenceId).filter(_.sequenceNumber <= maxSeqNr)
-
-  val selectByPersistenceIdAndMaxSequenceNr = Compiled(_selectByPersistenceIdAndMaxSequenceNr _)
-
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
-    _selectAllJournalForPersistenceId(persistenceId).take(1).map(_.sequenceNumber).max
+    JournalTable.filter(_.persistenceId === persistenceId).take(1).map(_.sequenceNumber).max
 
   val highestSequenceNrForPersistenceId = Compiled(_highestSequenceNrForPersistenceId _)
-
-  private def _allPersistenceIdsDistinct: Query[Rep[String], String, Seq] =
-    JournalTable.map(_.persistenceId).distinct
-
-  val allPersistenceIdsDistinct = Compiled(_allPersistenceIdsDistinct)
 
   private def _messagesQuery(
       persistenceId: Rep[String],

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -50,49 +50,29 @@ class JournalQueries(
     }
   }
 
-  private def selectAllJournalForPersistenceIdDesc(persistenceId: Rep[String]) =
-    selectAllJournalForPersistenceId(persistenceId).sortBy(_.sequenceNumber.desc)
-
-  private def selectAllJournalForPersistenceId(persistenceId: Rep[String]) =
-    JournalTable.filter(_.persistenceId === persistenceId).sortBy(_.sequenceNumber.desc)
-
   def delete(persistenceId: String, toSequenceNr: Long) = {
-    JournalTable.filter(_.persistenceId === persistenceId).filter(_.sequenceNumber <= toSequenceNr).delete
+    selectByPersistenceIdAndSequenceNr(persistenceId, toSequenceNr).delete
   }
 
-  def markJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long) =
-    JournalTable
-      .filter(_.persistenceId === persistenceId)
-      .filter(_.sequenceNumber <= maxSequenceNr)
-      .filter(_.deleted === false)
-      .map(_.deleted)
-      .update(true)
+  private def _selectAllJournalForPersistenceId(persistenceId: Rep[String]) =
+    _selectByPersistenceId(persistenceId).sortBy(_.sequenceNumber.desc)
+
+  private def _selectByPersistenceId(persistenceId: Rep[String]) =
+    JournalTable.filter(_.persistenceId === persistenceId)
+
+  private def _selectByPersistenceIdAndMaxSequenceNr(persistenceId: Rep[String], maxSeqNr: Rep[Long]) =
+    _selectByPersistenceId(persistenceId).filter(_.sequenceNumber <= maxSeqNr)
+  val selectByPersistenceIdAndSequenceNr = Compiled(_selectByPersistenceIdAndMaxSequenceNr _)
 
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
-    selectAllJournalForPersistenceId(persistenceId).take(1).map(_.sequenceNumber).max
-
-  private def _highestMarkedSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
-    selectAllJournalForPersistenceId(persistenceId).filter(_.deleted === true).take(1).map(_.sequenceNumber).max
+    _selectAllJournalForPersistenceId(persistenceId).take(1).map(_.sequenceNumber).max
 
   val highestSequenceNrForPersistenceId = Compiled(_highestSequenceNrForPersistenceId _)
-
-  val highestMarkedSequenceNrForPersistenceId = Compiled(_highestMarkedSequenceNrForPersistenceId _)
-
-  private def _selectByPersistenceIdAndMaxSequenceNumber(persistenceId: Rep[String], maxSequenceNr: Rep[Long]) =
-    selectAllJournalForPersistenceIdDesc(persistenceId).filter(_.sequenceNumber <= maxSequenceNr)
-
-  val selectByPersistenceIdAndMaxSequenceNumber = Compiled(_selectByPersistenceIdAndMaxSequenceNumber _)
 
   private def _allPersistenceIdsDistinct: Query[Rep[String], String, Seq] =
     JournalTable.map(_.persistenceId).distinct
 
   val allPersistenceIdsDistinct = Compiled(_allPersistenceIdsDistinct)
-
-  def journalRowByPersistenceIds(persistenceIds: Iterable[String]): Query[Rep[String], String, Seq] =
-    for {
-      query <- JournalTable.map(_.persistenceId)
-      if query.inSetBind(persistenceIds)
-    } yield query
 
   private def _messagesQuery(
       persistenceId: Rep[String],
@@ -101,9 +81,8 @@ class JournalQueries(
       max: ConstColumn[Long]) =
     JournalTable
       .filter(_.persistenceId === persistenceId)
-      .filter(_.deleted === false)
       .filter(_.sequenceNumber >= fromSequenceNr)
-      .filter(_.sequenceNumber <= toSequenceNr)
+      .filter(_.sequenceNumber <= toSequenceNr) // TODO optimized this avoid large offset query.
       .sortBy(_.sequenceNumber.asc)
       .take(max)
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -88,7 +88,7 @@ trait BaseByteArrayJournalDao
     // We should keep journal record with highest sequence number in order to be compliant
     // with @see [[pekko.persistence.journal.JournalSpec]]
     val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
-      highestSequenceNr <- queries.beforeHighestSequenceNrForPersistenceId(persistenceId, maxSequenceNr).result
+      highestSequenceNr <- queries.beforeHighestSequenceNrForPersistenceId((persistenceId, maxSequenceNr)).result
       _ <- queries.delete(persistenceId, highestSequenceNr - 1)
       _ <- queries.markMaxSequenceNrJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
     } yield ()

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -87,7 +87,7 @@ trait BaseByteArrayJournalDao
   override def delete(persistenceId: String, maxSequenceNr: Long): Future[Unit] = {
     // We should keep journal record with highest sequence number in order to be compliant
     // with @see [[pekko.persistence.journal.JournalSpec]]
-    db.run(queries.delete(persistenceId, maxSequenceNr - 1)).map(_ => ())
+    db.run(queries.delete(persistenceId, maxSequenceNr)).map(_ => ())
   }
 
   def update(persistenceId: String, sequenceNr: Long, payload: AnyRef): Future[Done] = {

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -88,8 +88,9 @@ trait BaseByteArrayJournalDao
     // We should keep journal record with highest sequence number in order to be compliant
     // with @see [[pekko.persistence.journal.JournalSpec]]
     val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
-      _ <- queries.delete(persistenceId, maxSequenceNr - 1)
-      _ <- queries.markMaxSequenceNrJournalMessagesAsDeleted(persistenceId, maxSequenceNr)
+      highestSequenceNr <- queries.beforeHighestSequenceNrForPersistenceId(persistenceId, maxSequenceNr).result
+      _ <- queries.delete(persistenceId, highestSequenceNr - 1)
+      _ <- queries.markMaxSequenceNrJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
     } yield ()
 
     db.run(actions.transactionally)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -90,7 +90,7 @@ trait BaseByteArrayJournalDao
     val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
       highestSequenceNr <- queries.highestSequenceNrForPersistenceIdBefore((persistenceId, maxSequenceNr)).result
       _ <- queries.delete(persistenceId, highestSequenceNr - 1)
-      _ <- queries.markJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
+      _ <- queries.markSeqNrJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
     } yield ()
 
     db.run(actions.transactionally)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -88,9 +88,9 @@ trait BaseByteArrayJournalDao
     // We should keep journal record with highest sequence number in order to be compliant
     // with @see [[pekko.persistence.journal.JournalSpec]]
     val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
-      highestSequenceNr <- queries.beforeHighestSequenceNrForPersistenceId((persistenceId, maxSequenceNr)).result
+      highestSequenceNr <- queries.highestSequenceNrForPersistenceIdBefore((persistenceId, maxSequenceNr)).result
       _ <- queries.delete(persistenceId, highestSequenceNr - 1)
-      _ <- queries.markMaxSequenceNrJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
+      _ <- queries.markJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
     } yield ()
 
     db.run(actions.transactionally)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -88,7 +88,8 @@ trait BaseByteArrayJournalDao
     // We should keep journal record with highest sequence number in order to be compliant
     // with @see [[pekko.persistence.journal.JournalSpec]]
     val actions: DBIOAction[Unit, NoStream, Effect.Write with Effect.Read] = for {
-      highestSequenceNr <- queries.highestSequenceNrForPersistenceIdBefore((persistenceId, maxSequenceNr)).result
+      seq <- queries.highestSequenceNrForPersistenceIdBefore((persistenceId, maxSequenceNr)).result
+      highestSequenceNr = seq.headOption.getOrElse(0L)
       _ <- queries.delete(persistenceId, highestSequenceNr - 1)
       _ <- queries.markSeqNrJournalMessagesAsDeleted(persistenceId, highestSequenceNr)
     } yield ()

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -87,7 +87,7 @@ trait BaseByteArrayJournalDao
   override def delete(persistenceId: String, maxSequenceNr: Long): Future[Unit] = {
     // We should keep journal record with highest sequence number in order to be compliant
     // with @see [[pekko.persistence.journal.JournalSpec]]
-    db.run(queries.delete(persistenceId, maxSequenceNr)).map(_ => ())
+    db.run(queries.delete(persistenceId, maxSequenceNr - 1)).map(_ => ())
   }
 
   def update(persistenceId: String, sequenceNr: Long, payload: AnyRef): Future[Done] = {

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
@@ -44,6 +44,14 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Leg
     baseQuery.map(_.message).update(replacement)
   }
 
+  def markMaxSequenceNrJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long) =
+    JournalTable
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.sequenceNumber === maxSequenceNr)
+      .filter(_.deleted === false)
+      .map(_.deleted)
+      .update(true)
+
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
     JournalTable
       .filter(_.persistenceId === persistenceId)
@@ -61,6 +69,7 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Leg
       max: ConstColumn[Long]) =
     JournalTable
       .filter(_.persistenceId === persistenceId)
+      .filter(_.deleted === false)
       .filter(_.sequenceNumber >= fromSequenceNr)
       .filter(_.sequenceNumber <= toSequenceNr)
       .sortBy(_.sequenceNumber.asc)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
@@ -60,13 +60,11 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Leg
     selectAllJournalForPersistenceId(persistenceId).take(1).map(_.sequenceNumber).max
 
   private def _highestSequenceNrForPersistenceIdBefore(
-      persistenceId: Rep[String], maxSequenceNr: Rep[Long]): Rep[Long] =
+      persistenceId: Rep[String], maxSequenceNr: Rep[Long]): Query[Rep[Long], Long, Seq] =
     selectAllJournalForPersistenceId(persistenceId)
       .filter(_.sequenceNumber <= maxSequenceNr)
-      .take(1)
       .map(_.sequenceNumber)
-      .max
-      .getOrElse(0L)
+      .take(1)
 
   private def _messagesQuery(
       persistenceId: Rep[String],

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
@@ -28,7 +28,10 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Leg
     JournalTableC ++= xs.sortBy(_.sequenceNumber)
 
   def delete(persistenceId: String, toSequenceNr: Long) = {
-    JournalTable.filter(_.persistenceId === persistenceId).filter(_.sequenceNumber <= toSequenceNr).delete
+    JournalTable
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.sequenceNumber <= toSequenceNr)
+      .delete
   }
 
   /**
@@ -42,7 +45,12 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Leg
   }
 
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
-    JournalTable.filter(_.persistenceId === persistenceId).take(1).map(_.sequenceNumber).max
+    JournalTable
+      .filter(_.persistenceId === persistenceId)
+      .sortBy(_.sequenceNumber.desc)
+      .take(1)
+      .map(_.sequenceNumber)
+      .max
 
   val highestSequenceNrForPersistenceId = Compiled(_highestSequenceNrForPersistenceId _)
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
@@ -31,7 +31,7 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Leg
     _selectByPersistenceId(persistenceId).sortBy(_.sequenceNumber.desc)
 
   def delete(persistenceId: String, toSequenceNr: Long) = {
-    selectByPersistenceIdAndSequenceNr(persistenceId, toSequenceNr).delete
+    selectByPersistenceIdAndMaxSequenceNr(persistenceId, toSequenceNr).delete
   }
 
   /**
@@ -49,7 +49,7 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Leg
 
   private def _selectByPersistenceIdAndMaxSequenceNr(persistenceId: Rep[String], maxSeqNr: Rep[Long]) =
     _selectByPersistenceId(persistenceId).filter(_.sequenceNumber <= maxSeqNr)
-  val selectByPersistenceIdAndSequenceNr = Compiled(_selectByPersistenceIdAndMaxSequenceNr _)
+  val selectByPersistenceIdAndMaxSequenceNr = Compiled(_selectByPersistenceIdAndMaxSequenceNr _)
 
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
     selectAllJournalForPersistenceId(persistenceId).take(1).map(_.sequenceNumber).max

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
@@ -48,10 +48,10 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Leg
     baseQuery.map(_.message).update(replacement)
   }
 
-  def markJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long) =
+  def markSeqNrJournalMessagesAsDeleted(persistenceId: String, sequenceNr: Long) =
     JournalTable
       .filter(_.persistenceId === persistenceId)
-      .filter(_.sequenceNumber === maxSequenceNr)
+      .filter(_.sequenceNumber === sequenceNr)
       .filter(_.deleted === false)
       .map(_.deleted)
       .update(true)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/dao/ReadJournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/dao/ReadJournalQueries.scala
@@ -25,11 +25,14 @@ class ReadJournalQueries(val profile: JdbcProfile, val readJournalConfig: ReadJo
 
   import profile.api._
 
+  private def baseTableQuery() =
+    JournalTable.filter(_.deleted === false)
+
   private def _allPersistenceIdsDistinct(max: ConstColumn[Long]): Query[Rep[String], String, Seq] =
-    JournalTable.map(_.persistenceId).distinct.take(max)
+    baseTableQuery().map(_.persistenceId).distinct.take(max)
 
   private def baseTableWithTagsQuery() = {
-    JournalTable.join(TagTable).on(_.ordering === _.eventId)
+    baseTableQuery().join(TagTable).on(_.ordering === _.eventId)
   }
 
   val allPersistenceIdsDistinct = Compiled(_allPersistenceIdsDistinct _)
@@ -39,7 +42,7 @@ class ReadJournalQueries(val profile: JdbcProfile, val readJournalConfig: ReadJo
       fromSequenceNr: Rep[Long],
       toSequenceNr: Rep[Long],
       max: ConstColumn[Long]) =
-    JournalTable
+    baseTableQuery()
       .filter(_.persistenceId === persistenceId)
       .filter(_.sequenceNumber >= fromSequenceNr)
       .filter(_.sequenceNumber <= toSequenceNr)


### PR DESCRIPTION
## Motivation

Resolve #155, improve the deletion performance.

- Avoid updating large rows(will only mark the highest journal as delete)
- Remove unused queries.