### PR TITLE
use new Source.queue to avoid memory leak

### DIFF
--- a/core/src/main/mima-filters/1.1.x.backwards.excludes/BaseDao.excludes
+++ b/core/src/main/mima-filters/1.1.x.backwards.excludes/BaseDao.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.journal.dao.BaseDao.writeQueue")

--- a/core/src/main/mima-filters/1.1.x.backwards.excludes/BaseDao.excludes
+++ b/core/src/main/mima-filters/1.1.x.backwards.excludes/BaseDao.excludes
@@ -1,1 +1,2 @@
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.journal.dao.BaseDao.writeQueue")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.BaseDao.writeQueue")

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/BaseDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/BaseDao.scala
@@ -29,7 +29,7 @@ abstract class BaseDao[T] {
 
   def baseDaoConfig: BaseDaoConfig
 
-  val writeQueue: BoundedSourceQueue[(Promise[Unit], Seq[T])] = Source
+  private val writeQueue: BoundedSourceQueue[(Promise[Unit], Seq[T])] = Source
     .queue[(Promise[Unit], Seq[T])](baseDaoConfig.bufferSize)
     .batchWeighted[(Seq[Promise[Unit]], Seq[T])](baseDaoConfig.batchSize, _._2.size, tup => Vector(tup._1) -> tup._2) {
       case ((promises, rows), (newPromise, newRows)) => (promises :+ newPromise) -> (rows ++ newRows)


### PR DESCRIPTION
## Motivation

the legacy usage of `Source.queue` has a memory leak issue, see: https://github.com/akka/akka/issues/25798, the newest API has been solved that.

This PR should cherry-pick to 1.0.x ?