### PR TITLE
Nightly pekko 1.1 tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - migration-tool # remove before merging to main
     tags-ignore: [ v.* ]
 
 jobs:

--- a/.github/workflows/h2-test.yml
+++ b/.github/workflows/h2-test.yml
@@ -46,7 +46,7 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
-        run: sbt -Dpekko.build.pekko.version=main "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
+        run: sbt "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/mysql-tests.yml
+++ b/.github/workflows/mysql-tests.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - migration-tool # remove before merging to main
     tags-ignore: [ v.* ]
 
 jobs:

--- a/.github/workflows/nightly-pekko-1.1-tests.yml
+++ b/.github/workflows/nightly-pekko-1.1-tests.yml
@@ -1,13 +1,11 @@
-name: H2 Unit Tests
+name: Nightly Testing with Pekko 1.1
 
 permissions: {}
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
-    tags-ignore: [ v.* ]
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   test:
@@ -20,9 +18,6 @@ jobs:
           - { java-version: 8,  scala-version: 2.12, sbt-opts: '' }
           - { java-version: 8,  scala-version: 2.13, sbt-opts: '' }
           - { java-version: 8,  scala-version: 3.3,  sbt-opts: '' }
-          - { java-version: 11, scala-version: 2.12, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { java-version: 11, scala-version: 2.13, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { java-version: 11, scala-version: 3.3,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-pekko-1.1-tests.yml
+++ b/.github/workflows/nightly-pekko-1.1-tests.yml
@@ -4,7 +4,7 @@ permissions: {}
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 4 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/nightly-pekko-1.1-tests.yml
+++ b/.github/workflows/nightly-pekko-1.1-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
-        run: sbt "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
+        run: sbt -Dpekko.build.pekko.version=main "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/nightly-pekko-1.1-tests.yml
+++ b/.github/workflows/nightly-pekko-1.1-tests.yml
@@ -46,7 +46,7 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
-        run: sbt -Dpekko.build.pekko.version=main "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
+        run: sbt "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/oracle-tests.yml
+++ b/.github/workflows/oracle-tests.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - migration-tool # remove before merging to main
     tags-ignore: [ v.* ]
 
 jobs:

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - migration-tool # remove before merging to main
     tags-ignore: [ v.* ]
 
 jobs:

--- a/.github/workflows/sqlserver-tests.yml
+++ b/.github/workflows/sqlserver-tests.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - migration-tool # remove before merging to main
     tags-ignore: [ v.* ]
 
 jobs:

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ sourceDistIncubating := false
 
 val mimaCompareVersion = "1.0.0"
 
+ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 lazy val `pekko-persistence-jdbc` = project


### PR DESCRIPTION
* When I run these locally I get 2 errors
* We need to keep better eye on whether pekko 1.1 breaks things
* also removes the support of migration-tool branch which no longer exists