### PR TITLE
fix: flaky H2ScalaAllPersistenceIdsTest (#199)

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -94,7 +94,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
     JournalSequenceActor.props(readJournalDao, readJournalConfig.journalSequenceRetrievalConfiguration),
     s"$configPath.pekko-persistence-jdbc-journal-sequence-actor")
   private val delaySource =
-    Source.tick(0.seconds, readJournalConfig.refreshInterval, 0).take(1)
+    Source.tick(0.seconds, readJournalConfig.refreshInterval, 0)
 
   /**
    * Same type of query as `persistenceIds` but the event stream


### PR DESCRIPTION
backport #199 to 1.0.x to avoid flaky

cherry pick 0d0a85d2fc46a3b7d75a3613db13e7065fae83fb