### PR TITLE
move scala-reflect to top of dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,13 +36,13 @@ lazy val core = project
   .disablePlugins(SitePlugin)
   .settings(
     name := "pekko-persistence-jdbc",
-    libraryDependencies ++= Dependencies.Libraries,
     // Transitive dependency `scala-reflect` to avoid `NoClassDefFoundError`.
     // See: https://github.com/slick/slick/issues/2933
     libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, _)) => Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
       case _            => Nil
     }),
+    libraryDependencies ++= Dependencies.Libraries,
     mimaReportSignatureProblems := true,
     mimaPreviousArtifacts := Set(
       organization.value %% name.value % mimaCompareVersion))


### PR DESCRIPTION
With #202, the pom has the scala-reflect dependency hidden at the bottom after all the test dependencies.

https://repository.apache.org/content/groups/staging/org/apache/pekko/pekko-persistence-jdbc_2.13/1.1.0-M1-RC2/pekko-persistence-jdbc_2.13-1.1.0-M1-RC2.pom

With this change, the dependency moves to 2nd - sbt adds scala-library dependency automatically and in first but by us listing scala-reflect first, it is listed in the pom 2nd after scala-library.