### PR TITLE
pekko 1.1.1

### DIFF
--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.1.0-M1"
+  override val currentVersion: String = "1.1.1"
 }


### PR DESCRIPTION
This is the last merge needed before we can do a pekko-persistence-jdbc 1.1.0 (RC1).