### PR TITLE
hikari 6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
     "org.apache.pekko" %% "pekko-persistence-query" % PekkoVersion,
     "com.typesafe.slick" %% "slick" % SlickVersion,
     "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,
+    "com.zaxxer" % "HikariCP" % "6.0.0",
     "ch.qos.logback" % "logback-classic" % LogbackVersion % Test,
     "org.apache.pekko" %% "pekko-slf4j" % PekkoVersion % Test,
     "org.apache.pekko" %% "pekko-persistence-tck" % PekkoVersion % Test,


### PR DESCRIPTION
now that we are pinned to an old version of Slick - we are stuck with its old version of hikari

Let's explicitly use a newer Hikari version. We are missing out on bug fixes.

https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES
