### PR TITLE
Fix gitignore for Metals via VS Code usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,13 @@ target
 .bsp
 *.code-workspace
 .bloop
-.metals
 dumps
+
+# Metals
+.bloop
+.metals
+metals.sbt
+project/project
+
+# VS Code
+.vscode


### PR DESCRIPTION
Fixes the `.gitignore` file to support code editing with Metals via VS Code. 