### PR TITLE
[NOT FOR MERGE] use pekko trait CurrentLastSequenceNumberByPersistenceIdQuery

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
@@ -14,11 +14,10 @@
 
 package org.apache.pekko.persistence.jdbc.query.javadsl
 
-import org.apache.pekko
-
 import java.util.Optional
 import java.util.concurrent.CompletionStage
 
+import org.apache.pekko
 import pekko.NotUsed
 import pekko.persistence.jdbc.query.scaladsl.{ JdbcReadJournal => ScalaJdbcReadJournal }
 import pekko.persistence.query.{ EventEnvelope, Offset }
@@ -38,7 +37,8 @@ class JdbcReadJournal(journal: ScalaJdbcReadJournal)
     with CurrentEventsByPersistenceIdQuery
     with EventsByPersistenceIdQuery
     with CurrentEventsByTagQuery
-    with EventsByTagQuery {
+    with EventsByTagQuery
+    with CurrentLastSequenceNumberByPersistenceIdQuery {
 
   /**
    * Same type of query as `persistenceIds` but the event stream
@@ -145,7 +145,7 @@ class JdbcReadJournal(journal: ScalaJdbcReadJournal)
    * @param persistenceId The `persistenceId` for which the last known sequence number should be returned.
    * @return Some sequence number or None if the `persistenceId` is unknown.
    */
-  def currentLastSequenceNumberByPersistenceId(persistenceId: String): CompletionStage[Optional[java.lang.Long]] =
+  override def currentLastSequenceNumberByPersistenceId(persistenceId: String): CompletionStage[Optional[java.lang.Long]] =
     journal
       .currentLastSequenceNumberByPersistenceId(persistenceId)
       .asJava

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -17,11 +17,13 @@ package scaladsl
 
 import org.apache.pekko
 import pekko.NotUsed
-import pekko.actor.ExtendedActorSystem
+import pekko.actor.{ ExtendedActorSystem, Scheduler }
 import pekko.persistence.jdbc.config.ReadJournalConfig
 import pekko.persistence.jdbc.query.JournalSequenceActor.{ GetMaxOrderingId, MaxOrderingId }
 import pekko.persistence.jdbc.db.SlickExtension
 import pekko.persistence.jdbc.journal.dao.FlowControl
+import pekko.persistence.jdbc.query.dao.ReadJournalDao
+import pekko.persistence.jdbc.util.PluginVersionChecker
 import pekko.persistence.query.scaladsl._
 import pekko.persistence.query.{ EventEnvelope, Offset, Sequence }
 import pekko.persistence.{ Persistence, PersistentRepr }
@@ -37,9 +39,6 @@ import scala.collection.immutable._
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
-import pekko.actor.Scheduler
-import pekko.persistence.jdbc.query.dao.ReadJournalDao
-import pekko.persistence.jdbc.util.PluginVersionChecker
 
 object JdbcReadJournal {
   final val Identifier = "jdbc-read-journal"
@@ -52,7 +51,8 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
     with CurrentEventsByPersistenceIdQuery
     with EventsByPersistenceIdQuery
     with CurrentEventsByTagQuery
-    with EventsByTagQuery {
+    with EventsByTagQuery
+    with CurrentLastSequenceNumberByPersistenceIdQuery {
 
   PluginVersionChecker.check()
 
@@ -324,6 +324,6 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
    * @param persistenceId The `persistenceId` for which the last known sequence number should be returned.
    * @return Some sequence number or None if the `persistenceId` is unknown.
    */
-  def currentLastSequenceNumberByPersistenceId(persistenceId: String): Future[Option[Long]] =
+  override def currentLastSequenceNumberByPersistenceId(persistenceId: String): Future[Option[Long]] =
     readJournalDao.lastPersistenceIdSequenceNumber(persistenceId)
 }


### PR DESCRIPTION
can only be merged after pekko 1.2.0 release and should only be released in a pekko-persistence-jdbc 1.2.0 release