### PR TITLE
use ubuntu 22 in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   check-code-style:
     name: Check Code Style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
 
   check-code-compilation:
     name: Check Code Compilation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
 
   check-docs:
     name: Check Docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/h2-test.yml
+++ b/.github/workflows/h2-test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     name: Build and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   check-headers:
     name: Check headers
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   validate-links:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/mysql-tests.yml
+++ b/.github/workflows/mysql-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
    integration-test:
     name: Integration Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-pekko-1.0-tests.yml
+++ b/.github/workflows/nightly-pekko-1.0-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Build and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/oracle-tests.yml
+++ b/.github/workflows/oracle-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
    integration-test:
     name: Integration Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
    integration-test:
     name: Integration Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -11,7 +11,7 @@ jobs:
     # runs on main repo only
     if: github.repository == 'apache/pekko-persistence-jdbc'
     name: Publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:

--- a/.github/workflows/publish-1.0-nightly.yml
+++ b/.github/workflows/publish-1.0-nightly.yml
@@ -12,7 +12,7 @@ jobs:
   publish10:
     if: github.repository == 'apache/pekko-persistence-jdbc'
     name: Publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:

--- a/.github/workflows/publish-1.1-docs.yml
+++ b/.github/workflows/publish-1.1-docs.yml
@@ -11,7 +11,7 @@ jobs:
     # runs on main repo only
     if: github.repository == 'apache/pekko-persistence-jdbc'
     name: Publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -13,7 +13,7 @@ jobs:
     # runs on main repo only
     if: github.repository == 'apache/pekko-persistence-jdbc'
     name: Publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:

--- a/.github/workflows/sqlserver-tests.yml
+++ b/.github/workflows/sqlserver-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
    integration-test:
     name: Integration Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sqlserver-tests.yml
+++ b/.github/workflows/sqlserver-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
    integration-test:
     name: Integration Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
brownout warnings for ubuntu 20

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/
