### PR TITLE
add H2 version of new durable state tests

### DIFF
--- a/core/src/main/resources/schema/h2/h2-create-schema-legacy.sql
+++ b/core/src/main/resources/schema/h2/h2-create-schema-legacy.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS PUBLIC."snapshot" (
 );
 
 
-CREATE TABLE IF NOT EXISTS "durable_state" (
+CREATE TABLE IF NOT EXISTS PUBLIC."durable_state" (
     "global_offset" BIGINT NOT NULL AUTO_INCREMENT,
     "persistence_id" VARCHAR(255) NOT NULL,
     "revision" BIGINT NOT NULL,
@@ -30,5 +30,5 @@ CREATE TABLE IF NOT EXISTS "durable_state" (
     PRIMARY KEY("persistence_id")
     );
 
-CREATE INDEX "state_tag_idx" on "durable_state" ("tag");
-CREATE INDEX "state_global_offset_idx" on "durable_state" ("global_offset");
+CREATE INDEX "state_tag_idx" on PUBLIC."durable_state" ("tag");
+CREATE INDEX "state_global_offset_idx" on PUBLIC."durable_state" ("global_offset");

--- a/core/src/main/resources/schema/h2/h2-create-schema.sql
+++ b/core/src/main/resources/schema/h2/h2-create-schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS "event_journal" (
+CREATE TABLE IF NOT EXISTS PUBLIC."event_journal" (
     "ordering" BIGINT UNIQUE NOT NULL AUTO_INCREMENT,
     "deleted" BOOLEAN DEFAULT false NOT NULL,
     "persistence_id" VARCHAR(255) NOT NULL,
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS "event_journal" (
 
 CREATE UNIQUE INDEX "event_journal_ordering_idx" on "event_journal" ("ordering");
 
-CREATE TABLE IF NOT EXISTS "event_tag" (
+CREATE TABLE IF NOT EXISTS PUBLIC."event_tag" (
     "event_id" BIGINT NOT NULL,
     "tag" VARCHAR NOT NULL,
     PRIMARY KEY("event_id", "tag"),
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS "event_tag" (
       ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS "snapshot" (
+CREATE TABLE IF NOT EXISTS PUBLIC."snapshot" (
     "persistence_id" VARCHAR(255) NOT NULL,
     "sequence_number" BIGINT NOT NULL,
     "created" BIGINT NOT NULL,"snapshot_ser_id" INTEGER NOT NULL,
@@ -39,9 +39,9 @@ CREATE TABLE IF NOT EXISTS "snapshot" (
     PRIMARY KEY("persistence_id","sequence_number")
     );
 
-CREATE SEQUENCE IF NOT EXISTS "global_offset_seq";
+CREATE SEQUENCE IF NOT EXISTS PUBLIC."global_offset_seq";
 
-CREATE TABLE IF NOT EXISTS "durable_state" (
+CREATE TABLE IF NOT EXISTS PUBLIC."durable_state" (
     "global_offset" BIGINT DEFAULT NEXT VALUE FOR "global_offset_seq",
     "persistence_id" VARCHAR(255) NOT NULL,
     "revision" BIGINT NOT NULL,
@@ -52,5 +52,5 @@ CREATE TABLE IF NOT EXISTS "durable_state" (
     "state_timestamp" BIGINT NOT NULL,
     PRIMARY KEY("persistence_id")
     );
-CREATE INDEX IF NOT EXISTS "state_tag_idx" on "durable_state" ("tag");
-CREATE INDEX IF NOT EXISTS "state_global_offset_idx" on "durable_state" ("global_offset");
+CREATE INDEX IF NOT EXISTS "state_tag_idx" on PUBLIC."durable_state" ("tag");
+CREATE INDEX IF NOT EXISTS "state_global_offset_idx" on PUBLIC."durable_state" ("global_offset");

--- a/core/src/main/resources/schema/h2/h2-create-schema.sql
+++ b/core/src/main/resources/schema/h2/h2-create-schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS PUBLIC."event_journal" (
     PRIMARY KEY("persistence_id","sequence_number")
     );
 
-CREATE UNIQUE INDEX "event_journal_ordering_idx" on "event_journal" ("ordering");
+CREATE UNIQUE INDEX "event_journal_ordering_idx" on PUBLIC."event_journal" ("ordering");
 
 CREATE TABLE IF NOT EXISTS PUBLIC."event_tag" (
     "event_id" BIGINT NOT NULL,
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS PUBLIC."snapshot" (
 CREATE SEQUENCE IF NOT EXISTS PUBLIC."global_offset_seq";
 
 CREATE TABLE IF NOT EXISTS PUBLIC."durable_state" (
-    "global_offset" BIGINT DEFAULT NEXT VALUE FOR "global_offset_seq",
+    "global_offset" BIGINT DEFAULT NEXT VALUE FOR PUBLIC."global_offset_seq",
     "persistence_id" VARCHAR(255) NOT NULL,
     "revision" BIGINT NOT NULL,
     "state_payload" BLOB NOT NULL,

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/testkit/internal/SchemaUtilsImpl.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/testkit/internal/SchemaUtilsImpl.scala
@@ -126,7 +126,8 @@ private[jdbc] object SchemaUtilsImpl {
     val (fileToLoad, separator) = createScriptFor(schemaType, false)
     val script = SchemaUtilsImpl.fromClasspathAsString(fileToLoad)
       .replaceAll(s"$oldSchemaName.", s"$newSchemaName.")
-    SchemaUtilsImpl.applyScriptWithSlick(script, separator, logger, db)
+    val scriptWithSchemaCreate = s"CREATE SCHEMA IF NOT EXISTS $newSchemaName$separator$script"
+    SchemaUtilsImpl.applyScriptWithSlick(scriptWithSchemaCreate, separator, logger, db)
   }
 
   private def applyScriptWithSlick(script: String, separator: String, logger: Logger, database: Database): Done = {

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/testkit/internal/SchemaUtilsImpl.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/testkit/internal/SchemaUtilsImpl.scala
@@ -100,9 +100,33 @@ private[jdbc] object SchemaUtilsImpl {
    * INTERNAL API
    */
   @InternalApi
+  private[jdbc] def dropWithSlickButChangeSchema(schemaType: SchemaType, logger: Logger, db: Database,
+      oldSchemaName: String, newSchemaName: String): Done = {
+    val (fileToLoad, separator) = dropScriptFor(schemaType, false)
+    val script = SchemaUtilsImpl.fromClasspathAsString(fileToLoad)
+      .replaceAll(s"$oldSchemaName.", s"$newSchemaName.")
+    SchemaUtilsImpl.applyScriptWithSlick(script, separator, logger, db)
+  }
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
   private[jdbc] def createWithSlick(schemaType: SchemaType, logger: Logger, db: Database, legacy: Boolean): Done = {
     val (fileToLoad, separator) = createScriptFor(schemaType, legacy)
     SchemaUtilsImpl.applyScriptWithSlick(SchemaUtilsImpl.fromClasspathAsString(fileToLoad), separator, logger, db)
+  }
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[jdbc] def createWithSlickButChangeSchema(schemaType: SchemaType, logger: Logger, db: Database,
+      oldSchemaName: String, newSchemaName: String): Done = {
+    val (fileToLoad, separator) = createScriptFor(schemaType, false)
+    val script = SchemaUtilsImpl.fromClasspathAsString(fileToLoad)
+      .replaceAll(s"$oldSchemaName.", s"$newSchemaName.")
+    SchemaUtilsImpl.applyScriptWithSlick(script, separator, logger, db)
   }
 
   private def applyScriptWithSlick(script: String, separator: String, logger: Logger, database: Database): Done = {
@@ -152,7 +176,11 @@ private[jdbc] object SchemaUtilsImpl {
     }
   }
 
-  private def slickProfileToSchemaType(profile: JdbcProfile): SchemaType =
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[jdbc] def slickProfileToSchemaType(profile: JdbcProfile): SchemaType =
     profile match {
       case PostgresProfile  => Postgres
       case MySQLProfile     => MySQL

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
@@ -89,10 +89,12 @@ abstract class DurableStateStoreSchemaPluginSpec(val config: Config, profile: Jd
     new SlickConfiguration(config.getConfig("slick")), "slick.db"
   )
 
-  override def beforeAll(): Unit = {
+  override def beforeAll(): Unit =
     dropAndCreateWithSchema(SchemaUtilsImpl.slickProfileToSchemaType(profile),
       defaultSchemaName, schemaName)
-  }
+
+  override def afterAll(): Unit =
+    system.terminate().futureValue
 
   "A durable state store plugin" must {
     "instantiate a JdbcDurableDataStore successfully" in {
@@ -120,17 +122,15 @@ abstract class DurableStateStoreSchemaPluginSpec(val config: Config, profile: Jd
     }
   }
 
-  override def afterAll(): Unit = {
-    system.terminate().futureValue
-
-  }
 }
 
 class H2DurableStateStorePluginSpec
     extends DurableStateStorePluginSpec(ConfigFactory.load("h2-application.conf"), H2Profile)
 
+/*
 class H2DurableStateStorePluginSchemaSpec
     extends DurableStateStoreSchemaPluginSpec(ConfigFactory.load("h2-application.conf"),
       H2Profile) {
   override protected def defaultSchemaName: String = "PUBLIC"
 }
+

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
@@ -132,10 +132,8 @@ abstract class DurableStateStoreSchemaPluginSpec(val config: Config, profile: Jd
 class H2DurableStateStorePluginSpec
     extends DurableStateStorePluginSpec(ConfigFactory.load("h2-application.conf"), H2Profile)
 
-/*
 class H2DurableStateStorePluginSchemaSpec
     extends DurableStateStoreSchemaPluginSpec(ConfigFactory.load("h2-application.conf"),
       H2Profile) {
   override protected def defaultSchemaName: String = "PUBLIC"
 }
- */

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
@@ -50,7 +50,6 @@ abstract class DurableStateStorePluginSpec(config: Config, profile: JdbcProfile)
   }
 
   override def afterAll(): Unit = {
-    db.close()
     system.terminate().futureValue
   }
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
@@ -11,19 +11,19 @@ package org.apache.pekko.persistence.jdbc.state.scaladsl
 
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.apache.pekko
-import org.apache.pekko.persistence.jdbc.config.SlickConfiguration
-import org.apache.pekko.persistence.jdbc.db.SlickDatabase
-import org.apache.pekko.persistence.jdbc.testkit.internal.Postgres
-import org.apache.pekko.persistence.jdbc.util.DropCreate
-import org.apache.pekko.util.Timeout
 import pekko.actor._
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
+import pekko.persistence.jdbc.config.SlickConfiguration
+import pekko.persistence.jdbc.db.SlickDatabase
+import pekko.persistence.jdbc.testkit.internal.SchemaUtilsImpl
+import pekko.persistence.jdbc.util.DropCreate
+import pekko.persistence.state.DurableStateStoreRegistry
+import pekko.util.Timeout
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{ Millis, Seconds, Span }
-import pekko.persistence.state.DurableStateStoreRegistry
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.BeforeAndAfterAll
 import slick.jdbc.{ H2Profile, JdbcProfile }
 
 import scala.concurrent.duration.DurationInt
@@ -54,15 +54,15 @@ abstract class DurableStateStorePluginSpec(config: Config, profile: JdbcProfile)
   }
 }
 
-abstract class DurableStateStorePostgresSchemaPluginSpec(val config: Config, profile: JdbcProfile)
+abstract class DurableStateStoreSchemaPluginSpec(val config: Config, profile: JdbcProfile)
     extends AnyWordSpecLike
     with BeforeAndAfterAll
-    with BeforeAndAfterEach
     with Matchers
     with ScalaFutures
     with DropCreate
     with DataGenerationHelper {
 
+  protected def defaultSchemaName: String = "public"
   val schemaName: String = "pekko"
   implicit val timeout: Timeout = Timeout(1.minute)
   implicit val defaultPatience: PatienceConfig =
@@ -89,18 +89,9 @@ abstract class DurableStateStorePostgresSchemaPluginSpec(val config: Config, pro
     new SlickConfiguration(config.getConfig("slick")), "slick.db"
   )
 
-  private val createSchema = s"CREATE SCHEMA IF NOT EXISTS $schemaName;"
-  private val moveDurableStateTableToSchema = s"alter table public.durable_state set schema $schemaName;"
-  private val moveDurableStateTableToPublic = s"alter table $schemaName.durable_state set schema public;"
-  private val createSchemaAndMoveTable = s"${createSchema}${moveDurableStateTableToSchema}"
-  private val removeTableFromSchema = s"${moveDurableStateTableToPublic}"
-
   override def beforeAll(): Unit = {
-    dropAndCreate(Postgres)
-  }
-
-  override def beforeEach(): Unit = {
-    withStatement(_.execute(createSchemaAndMoveTable))
+    dropAndCreateWithSchema(SchemaUtilsImpl.slickProfileToSchemaType(profile),
+      defaultSchemaName, schemaName)
   }
 
   "A durable state store plugin" must {
@@ -129,10 +120,6 @@ abstract class DurableStateStorePostgresSchemaPluginSpec(val config: Config, pro
     }
   }
 
-  override def afterEach(): Unit = {
-    withStatement(_.execute(removeTableFromSchema))
-  }
-
   override def afterAll(): Unit = {
     system.terminate().futureValue
 
@@ -141,3 +128,9 @@ abstract class DurableStateStorePostgresSchemaPluginSpec(val config: Config, pro
 
 class H2DurableStateStorePluginSpec
     extends DurableStateStorePluginSpec(ConfigFactory.load("h2-application.conf"), H2Profile)
+
+class H2DurableStateStorePluginSchemaSpec
+    extends DurableStateStoreSchemaPluginSpec(ConfigFactory.load("h2-application.conf"),
+      H2Profile) {
+  override protected def defaultSchemaName: String = "PUBLIC"
+}

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
@@ -68,7 +68,7 @@ abstract class DurableStateStoreSchemaPluginSpec(val config: Config, profile: Jd
   implicit val defaultPatience: PatienceConfig =
     PatienceConfig(timeout = Span(60, Seconds), interval = Span(100, Millis))
 
-  val customConfig: Config = ConfigFactory.parseString(s"""
+  val customConfig: Config = ConfigFactory.parseString("""
     jdbc-durable-state-store {
       tables {
         durable_state {

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
@@ -50,6 +50,7 @@ abstract class DurableStateStorePluginSpec(config: Config, profile: JdbcProfile)
   }
 
   override def afterAll(): Unit = {
+    db.close()
     system.terminate().futureValue
   }
 }
@@ -98,6 +99,7 @@ abstract class DurableStateStoreSchemaPluginSpec(val config: Config, profile: Jd
     SchemaUtilsImpl.dropWithSlickButChangeSchema(
       SchemaUtilsImpl.slickProfileToSchemaType(profile),
       logger, db, defaultSchemaName, schemaName)
+    db.close()
     system.terminate().futureValue
   }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
@@ -133,4 +133,4 @@ class H2DurableStateStorePluginSchemaSpec
       H2Profile) {
   override protected def defaultSchemaName: String = "PUBLIC"
 }
-
+ */

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
@@ -11,13 +11,22 @@ package org.apache.pekko.persistence.jdbc.state.scaladsl
 
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.apache.pekko
+import org.apache.pekko.persistence.jdbc.config.SlickConfiguration
+import org.apache.pekko.persistence.jdbc.db.SlickDatabase
+import org.apache.pekko.persistence.jdbc.testkit.internal.Postgres
+import org.apache.pekko.persistence.jdbc.util.DropCreate
+import org.apache.pekko.util.Timeout
 import pekko.actor._
-import pekko.persistence.state.DurableStateStoreRegistry
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
+import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{ Millis, Seconds, Span }
+import pekko.persistence.state.DurableStateStoreRegistry
 import slick.jdbc.{ H2Profile, JdbcProfile }
+
+import scala.concurrent.duration.DurationInt
 
 abstract class DurableStateStorePluginSpec(config: Config, profile: JdbcProfile)
     extends AnyWordSpecLike
@@ -42,6 +51,91 @@ abstract class DurableStateStorePluginSpec(config: Config, profile: JdbcProfile)
 
   override def afterAll(): Unit = {
     system.terminate().futureValue
+  }
+}
+
+abstract class DurableStateStorePostgresSchemaPluginSpec(val config: Config, profile: JdbcProfile)
+    extends AnyWordSpecLike
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with Matchers
+    with ScalaFutures
+    with DropCreate
+    with DataGenerationHelper {
+
+  val schemaName: String = "pekko"
+  implicit val timeout: Timeout = Timeout(1.minute)
+  implicit val defaultPatience: PatienceConfig =
+    PatienceConfig(timeout = Span(60, Seconds), interval = Span(100, Millis))
+
+  val customConfig: Config = ConfigFactory.parseString(s"""
+    jdbc-durable-state-store {
+      tables {
+        durable_state {
+          schemaName = "pekko"
+        }
+      }
+    }
+  """)
+
+  implicit lazy val system: ExtendedActorSystem =
+    ActorSystem(
+      "test",
+      customConfig.withFallback(config)
+    ).asInstanceOf[ExtendedActorSystem]
+
+  lazy val db = SlickDatabase.database(
+    config,
+    new SlickConfiguration(config.getConfig("slick")), "slick.db"
+  )
+
+  private val createSchema = s"CREATE SCHEMA IF NOT EXISTS $schemaName;"
+  private val moveDurableStateTableToSchema = s"alter table public.durable_state set schema $schemaName;"
+  private val moveDurableStateTableToPublic = s"alter table $schemaName.durable_state set schema public;"
+  private val createSchemaAndMoveTable = s"${createSchema}${moveDurableStateTableToSchema}"
+  private val removeTableFromSchema = s"${moveDurableStateTableToPublic}"
+
+  override def beforeAll(): Unit = {
+    dropAndCreate(Postgres)
+  }
+
+  override def beforeEach(): Unit = {
+    withStatement(_.execute(createSchemaAndMoveTable))
+  }
+
+  "A durable state store plugin" must {
+    "instantiate a JdbcDurableDataStore successfully" in {
+
+      val store = DurableStateStoreRegistry
+        .get(system)
+        .durableStateStoreFor[JdbcDurableStateStore[String]](JdbcDurableStateStore.Identifier)
+
+      store shouldBe a[JdbcDurableStateStore[_]]
+      store.system.settings.config shouldBe system.settings.config
+      store.profile shouldBe profile
+    }
+
+    "persist states successfully" in {
+
+      val store = DurableStateStoreRegistry
+        .get(system)
+        .durableStateStoreFor[JdbcDurableStateStore[String]](JdbcDurableStateStore.Identifier)
+
+      upsertManyForOnePersistenceId(store, "durable_state", "durable-t1", 1, 400).size shouldBe 400
+
+      eventually {
+        store.maxStateStoreOffset().futureValue shouldBe 400
+      }
+    }
+  }
+
+  override def afterEach(): Unit = {
+    withStatement(_.execute(removeTableFromSchema))
+  }
+
+  override def afterAll(): Unit = {
+    system.terminate().futureValue
+
   }
 }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/util/DropCreate.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/util/DropCreate.scala
@@ -47,6 +47,17 @@ private[jdbc] trait DropCreate {
     SchemaUtilsImpl.createWithSlick(schemaType, logger, db, !newDao)
   }
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[jdbc] def dropAndCreateWithSchema(schemaType: SchemaType,
+      oldSchemaName: String, schemaName: String): Unit = {
+    // blocking calls, usually done in our before test methods
+    SchemaUtilsImpl.dropWithSlickButChangeSchema(schemaType, logger, db, oldSchemaName, schemaName)
+    SchemaUtilsImpl.createWithSlickButChangeSchema(schemaType, logger, db, oldSchemaName, schemaName)
+  }
+
   def withSession[A](f: Session => A): A = {
     withDatabase { db =>
       val session = db.createSession()

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/util/DropCreate.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/util/DropCreate.scala
@@ -47,17 +47,6 @@ private[jdbc] trait DropCreate {
     SchemaUtilsImpl.createWithSlick(schemaType, logger, db, !newDao)
   }
 
-  /**
-   * INTERNAL API
-   */
-  @InternalApi
-  private[jdbc] def dropAndCreateWithSchema(schemaType: SchemaType,
-      oldSchemaName: String, schemaName: String): Unit = {
-    // blocking calls, usually done in our before test methods
-    SchemaUtilsImpl.dropWithSlickButChangeSchema(schemaType, logger, db, oldSchemaName, schemaName)
-    SchemaUtilsImpl.createWithSlickButChangeSchema(schemaType, logger, db, oldSchemaName, schemaName)
-  }
-
   def withSession[A](f: Session => A): A = {
     withDatabase { db =>
       val session = db.createSession()

--- a/integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/integration/PostgresDurableStateStorePluginSpec.scala
+++ b/integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/integration/PostgresDurableStateStorePluginSpec.scala
@@ -20,5 +20,5 @@ class PostgresDurableStateStorePluginSpec
     extends DurableStateStorePluginSpec(ConfigFactory.load("postgres-shared-db-application.conf"), PostgresProfile) {}
 
 class PostgresDurableStateStorePluginSchemaSpec
-    extends DurableStateStorePostgresSchemaPluginSpec(ConfigFactory.load("postgres-application.conf"),
+    extends DurableStateStoreSchemaPluginSpec(ConfigFactory.load("postgres-application.conf"),
       PostgresProfile) {}

--- a/integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/integration/PostgresDurableStateStorePluginSpec.scala
+++ b/integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/integration/PostgresDurableStateStorePluginSpec.scala
@@ -13,7 +13,7 @@ import com.typesafe.config.ConfigFactory
 import slick.jdbc.PostgresProfile
 import org.apache.pekko.persistence.jdbc.state.scaladsl.{
   DurableStateStorePluginSpec,
-  DurableStateStorePostgresSchemaPluginSpec
+  DurableStateStoreSchemaPluginSpec
 }
 
 class PostgresDurableStateStorePluginSpec

--- a/integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/integration/PostgresDurableStateStorePluginSpec.scala
+++ b/integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/integration/PostgresDurableStateStorePluginSpec.scala
@@ -11,11 +11,14 @@ package org.apache.pekko.persistence.jdbc.integration
 
 import com.typesafe.config.ConfigFactory
 import slick.jdbc.PostgresProfile
-import org.apache.pekko.persistence.jdbc.state.scaladsl.{DurableStateStorePluginSpec, DurableStateStorePostgresSchemaPluginSpec}
+import org.apache.pekko.persistence.jdbc.state.scaladsl.{
+  DurableStateStorePluginSpec,
+  DurableStateStorePostgresSchemaPluginSpec
+}
 
 class PostgresDurableStateStorePluginSpec
     extends DurableStateStorePluginSpec(ConfigFactory.load("postgres-shared-db-application.conf"), PostgresProfile) {}
 
-
 class PostgresDurableStateStorePluginSchemaSpec
-    extends DurableStateStorePostgresSchemaPluginSpec(ConfigFactory.load("postgres-application.conf"), PostgresProfile) {}
+    extends DurableStateStorePostgresSchemaPluginSpec(ConfigFactory.load("postgres-application.conf"),
+      PostgresProfile) {}

--- a/integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/integration/PostgresDurableStateStorePluginSpec.scala
+++ b/integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/integration/PostgresDurableStateStorePluginSpec.scala
@@ -9,114 +9,13 @@
 
 package org.apache.pekko.persistence.jdbc.integration
 
-import com.typesafe.config.{ Config, ConfigFactory }
-import org.apache.pekko
-import pekko.util.Timeout
-import pekko.actor.{ ActorSystem, ExtendedActorSystem }
-import pekko.persistence.jdbc.config.SlickConfiguration
-import pekko.persistence.jdbc.db.SlickDatabase
-import pekko.persistence.jdbc.state.scaladsl.{
-  DataGenerationHelper,
-  DurableStateStorePluginSpec,
-  JdbcDurableStateStore
-}
-import pekko.persistence.jdbc.testkit.internal.Postgres
-import pekko.persistence.jdbc.util.DropCreate
-import pekko.persistence.state.DurableStateStoreRegistry
+import com.typesafe.config.ConfigFactory
 import slick.jdbc.PostgresProfile
-import org.scalatest.concurrent.Eventually.eventually
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.time.{ Millis, Seconds, Span }
-import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
-import scala.concurrent.duration.DurationInt
+import org.apache.pekko.persistence.jdbc.state.scaladsl.{DurableStateStorePluginSpec, DurableStateStorePostgresSchemaPluginSpec}
 
 class PostgresDurableStateStorePluginSpec
     extends DurableStateStorePluginSpec(ConfigFactory.load("postgres-shared-db-application.conf"), PostgresProfile) {}
 
+
 class PostgresDurableStateStorePluginSchemaSpec
-    extends AnyWordSpecLike
-    with BeforeAndAfterAll
-    with BeforeAndAfterEach
-    with Matchers
-    with ScalaFutures
-    with DropCreate
-    with DataGenerationHelper {
-
-  val profile = PostgresProfile
-  val config = ConfigFactory.load("postgres-application.conf")
-  val schemaName: String = "pekko"
-  implicit val timeout: Timeout = Timeout(1.minute)
-  implicit val defaultPatience: PatienceConfig =
-    PatienceConfig(timeout = Span(60, Seconds), interval = Span(100, Millis))
-
-  val customConfig: Config = ConfigFactory.parseString(s"""
-    jdbc-durable-state-store {
-      tables {
-        durable_state {
-          schemaName = "pekko"
-        }
-      }
-    }
-  """)
-
-  implicit lazy val system: ExtendedActorSystem =
-    ActorSystem(
-      "test",
-      customConfig.withFallback(config)
-    ).asInstanceOf[ExtendedActorSystem]
-
-  lazy val db = SlickDatabase.database(
-    config,
-    new SlickConfiguration(config.getConfig("slick")), "slick.db"
-  )
-
-  private val createSchema = s"CREATE SCHEMA IF NOT EXISTS $schemaName;"
-  private val moveDurableStateTableToSchema = s"alter table public.durable_state set schema $schemaName;"
-  private val moveDurableStateTableToPublic = s"alter table $schemaName.durable_state set schema public;"
-  private val createSchemaAndMoveTable = s"${createSchema}${moveDurableStateTableToSchema}"
-
-  override def beforeAll(): Unit = {
-    dropAndCreate(Postgres)
-  }
-
-  override def beforeEach(): Unit = {
-    withStatement(_.execute(createSchemaAndMoveTable))
-  }
-
-  "A durable state store plugin" must {
-    "instantiate a JdbcDurableDataStore successfully" in {
-
-      val store = DurableStateStoreRegistry
-        .get(system)
-        .durableStateStoreFor[JdbcDurableStateStore[String]](JdbcDurableStateStore.Identifier)
-
-      store shouldBe a[JdbcDurableStateStore[_]]
-      store.system.settings.config shouldBe system.settings.config
-      store.profile shouldBe profile
-    }
-
-    "persist states successfully" in {
-
-      val store = DurableStateStoreRegistry
-        .get(system)
-        .durableStateStoreFor[JdbcDurableStateStore[String]](JdbcDurableStateStore.Identifier)
-
-      upsertManyForOnePersistenceId(store, "durable_state", "durable-t1", 1, 400).size shouldBe 400
-
-      eventually {
-        store.maxStateStoreOffset().futureValue shouldBe 400
-      }
-    }
-  }
-
-  override def afterEach(): Unit = {
-    withStatement(_.execute(moveDurableStateTableToPublic))
-  }
-
-  override def afterAll(): Unit = {
-    system.terminate().futureValue
-
-  }
-}
+    extends DurableStateStorePostgresSchemaPluginSpec(ConfigFactory.load("postgres-application.conf"), PostgresProfile) {}


### PR DESCRIPTION
* follow up to #276 
* I looked at the SQL files for Oracle, MySQL and SQLServer and think it is best to not mess with them
* My view is to wait for people who want schema support to work for Oracle, MySQL and SQLServer to help in setting up tests, etc.
* afaics MySQL does not differentiate between databases and schemas - https://dev.mysql.com/doc/refman/8.4/en/glossary.html#glos_schema - so probably best to encourage MySQL users just to create extra databases instead of schemas
