### PR TITLE
GitHub CI no longer supports ubuntu 20

### DIFF
--- a/.github/workflows/sqlserver-tests.yml
+++ b/.github/workflows/sqlserver-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
    integration-test:
     name: Integration Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sqlserver-tests.yml
+++ b/.github/workflows/sqlserver-tests.yml
@@ -39,6 +39,9 @@ jobs:
           distribution: temurin
           java-version: 11
 
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 

--- a/.github/workflows/sqlserver-tests.yml
+++ b/.github/workflows/sqlserver-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
    integration-test:
     name: Integration Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/core/src/test/resources/sqlserver-application.conf
+++ b/core/src/test/resources/sqlserver-application.conf
@@ -79,7 +79,7 @@ slick {
     host = ${?DB_HOST}
     url = "jdbc:sqlserver://"${slick.db.host}":1433;databaseName=docker;integratedSecurity=false;encrypt=false;"
     user = "docker"
-    password = "docker"
+    password = "Str0ngPassword"
     driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
     numThreads = 5
     maxConnections = 5

--- a/core/src/test/resources/sqlserver-shared-db-application.conf
+++ b/core/src/test/resources/sqlserver-shared-db-application.conf
@@ -41,7 +41,7 @@ pekko-persistence-jdbc {
         host = ${?DB_HOST}
         url = "jdbc:sqlserver://"${pekko-persistence-jdbc.shared-databases.slick.db.host}":1433;databaseName=docker;integratedSecurity=false;encrypt=false;"
         user = "docker"
-        password = "docker"
+        password = "Str0ngPassword"
         driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
         numThreads = 5
         maxConnections = 5

--- a/migrator-integration-test/src/test/resources/sqlserver-application.conf
+++ b/migrator-integration-test/src/test/resources/sqlserver-application.conf
@@ -58,7 +58,7 @@ slick {
     host = ${?DB_HOST}
     url = "jdbc:sqlserver://"${slick.db.host}":1433;databaseName=docker;integratedSecurity=false;encrypt=false;"
     user = "docker"
-    password = "docker"
+    password = "Str0ngPassword"
     driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
     numThreads = 5
     maxConnections = 5

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "1521:1521" # DB_CONN: credentials (system:oracle | pass: oracle)
 
   sqlserver:
-    image: pjfanning/mmssql-server:2022-latest
+    image: pjfanning/mssql-server:2022-latest
     container_name: sqlserver-test
     environment:
       - "TZ=Europe/Amsterdam"

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -34,14 +34,12 @@ services:
       - "1521:1521" # DB_CONN: credentials (system:oracle | pass: oracle)
 
   sqlserver:
-    image: topaztechnology/mssql-server-linux
+    image: pjfanning/mmssql-server:2022-latest
     container_name: sqlserver-test
     environment:
       - "TZ=Europe/Amsterdam"
       - "DBCA_TOTAL_MEMORY=1024"
       - "ACCEPT_EULA=Y"
-      - "SQL_USER=docker"
-      - "SQL_PASSWORD=docker"
-      - "SQL_DB=docker"
+      - "MSSQL_SA_PASSWORD=Str0ngPassword"
     ports:
-      - "1433:1433" # credentials (docker:docker)
+      - "1433:1433" # credentials (docker:Str0ngPassword)

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -2,7 +2,6 @@
 # To start all docker containers required to execute the tests locally run:
 # docker compose up
 
-version: '2.2'
 services:
   postgres:
     image: postgres:latest

--- a/scripts/sqlserver-cli.sh
+++ b/scripts/sqlserver-cli.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "==================  Help for SqlServer cli  ========================"
 echo "================================================================="
-docker exec -it sqlserver-test /opt/mssql-tools/bin/sqlcmd -S localhost -U docker -P docker -d docker
+docker exec -it sqlserver-test /opt/mssql-tools18/bin/sqlcmd -S localhost -U docker -P Str0ngPassword -d docker


### PR DESCRIPTION
since today (April 15)

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

The existing Docker image used in tests does not seem to work in Ubuntu 22 or 24. I am trying out a new one but there is still work to do. I need to work out why the db schema is not being added in the tests any more.