### PR TITLE
Update .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,9 +1,7 @@
-pullRequests.frequency = "@monthly"
-
 updates.ignore = [
 ]
 
-updatePullRequests = never
+updatePullRequests = "always"
 
 updates.pin = [
   # Pin logback to v1.3.x because v1.4.x needs JDK11


### PR DESCRIPTION
* setup more closely matches https://github.com/apache/pekko/blob/main/.scala-steward.conf
* means that we get PRs when new jars appear instead of waiting one month for them - so we will know sooner about issues with dependencies