### PR TITLE
chore: update scala3Next to 3.9.0-RC3

### DIFF
--- a/.github/scripts/resolve-scala-version.sh
+++ b/.github/scripts/resolve-scala-version.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+scala_version="${1:?scala version is required}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+resolve_from_build() {
+  local pattern="$1"
+  local resolved
+  resolved="$(sed -n "$pattern" "$repo_root/project/Dependencies.scala")"
+  if [ -z "$resolved" ]; then
+    echo "Unable to resolve Scala version '$scala_version' from project/Dependencies.scala" >&2
+    exit 1
+  fi
+  printf '%s\n' "$resolved"
+}
+
+case "$scala_version" in
+  2.13 | 2.13.x | scala213)
+    resolve_from_build 's/.*val Scala213 = "\(.*\)".*/\1/p'
+    ;;
+  3.3 | 3.3.x | scala3)
+    resolve_from_build 's/.*val Scala3 = "\(.*\)".*/\1/p'
+    ;;
+  next)
+    resolve_from_build 's/.*val Scala3Next = "\(.*\)".*/\1/p'
+    ;;
+  *)
+    printf '%s\n' "$scala_version"
+    ;;
+esac

--- a/.github/workflows/h2-test.yml
+++ b/.github/workflows/h2-test.yml
@@ -19,10 +19,10 @@ jobs:
         include:
           - { java-version: 17, scala-version: 2.13, sbt-opts: '' }
           - { java-version: 17, scala-version: 3.3,  sbt-opts: '' }
-          - { java-version: 17, scala-version: 3.8,  sbt-opts: '' }
+          - { java-version: 17, scala-version: next,  sbt-opts: '' }
           - { java-version: 21, scala-version: 2.13, sbt-opts: '' }
           - { java-version: 21, scala-version: 3.3,  sbt-opts: '' }
-          - { java-version: 21, scala-version: 3.8,  sbt-opts: '' }
+          - { java-version: 21, scala-version: next,  sbt-opts: '' }
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -49,7 +49,9 @@ jobs:
         uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
-        run: sbt ++${{ matrix.scala-version }} "core/test; migrator/test" ${{ matrix.sbt-opts }}
+        run: |-
+          scala_version="$(bash .github/scripts/resolve-scala-version.sh "${{ matrix.scala-version }}")"
+          sbt "++${scala_version}!" "core/test; migrator/test" ${{ matrix.sbt-opts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   // Keep in sync with .github CI build
   val Scala213 = "2.13.18"
   val Scala3 = "3.3.8"
-  val Scala3Next = "3.9.0-RC1"
+  val Scala3Next = "3.9.0-RC3"
   val ScalaVersions = Seq(Scala213, Scala3, Scala3Next)
 
   val PekkoVersion = PekkoCoreDependency.version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   // Keep in sync with .github CI build
   val Scala213 = "2.13.18"
   val Scala3 = "3.3.8"
-  val Scala3Next = "3.8.4"
+  val Scala3Next = "3.9.0-RC1"
   val ScalaVersions = Seq(Scala213, Scala3, Scala3Next)
 
   val PekkoVersion = PekkoCoreDependency.version


### PR DESCRIPTION
### Motivation
Scala 3.9.0-RC3 is available and should be tested as the next Scala version.

### Modification
Update scala3Next version from 3.8.4 to 3.9.0-RC3.

### Result
Build will use Scala 3.9.0-RC3 as the next Scala version.

### Tests
Not run - version bump only

### References
None - version bump