### PR TITLE
Close Slick databases that are created but never closed

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/state/JdbcDurableStateStoreProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/state/JdbcDurableStateStoreProvider.scala
@@ -38,6 +38,14 @@ class JdbcDurableStateStoreProvider[A](system: ExtendedActorSystem) extends Dura
     SlickExtension(system).database(config.getConfig(scaladsl.JdbcDurableStateStore.Identifier))
   def db: Database = slickDb.database
 
+  if (slickDb.allowShutdown) {
+    // the database was created for this provider only, so it must be closed when the actor system terminates,
+    // otherwise its connection pool (and the threads it owns) outlives the actor system
+    system.registerOnTermination {
+      db.close()
+    }
+  }
+
   lazy val durableStateConfig = new DurableStateTableConfiguration(
     config.getConfig(scaladsl.JdbcDurableStateStore.Identifier))
   lazy val serialization = SerializationExtension(system)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/testkit/internal/SchemaUtilsImpl.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/testkit/internal/SchemaUtilsImpl.scala
@@ -53,8 +53,9 @@ private[jdbc] object SchemaUtilsImpl {
         slickProfileToSchemaType(slickDb.profile),
         legacy(configKey, actorSystem.classicSystem.settings.config))
 
+    val database = closeOnTermination(slickDb)
     val blockingEC = actorSystem.classicSystem.dispatchers.lookup(Dispatchers.DefaultBlockingDispatcherId)
-    Future(applyScriptWithSlick(fromClasspathAsString(fileToLoad), separator, logger, slickDb.database))(blockingEC)
+    Future(applyScriptWithSlick(fromClasspathAsString(fileToLoad), separator, logger, database))(blockingEC)
   }
 
   /**
@@ -70,8 +71,9 @@ private[jdbc] object SchemaUtilsImpl {
         slickProfileToSchemaType(slickDb.profile),
         legacy(configKey, actorSystem.classicSystem.settings.config))
 
+    val database = closeOnTermination(slickDb)
     val blockingEC = actorSystem.classicSystem.dispatchers.lookup(Dispatchers.DefaultBlockingDispatcherId)
-    Future(applyScriptWithSlick(fromClasspathAsString(fileToLoad), separator, logger, slickDb.database))(blockingEC)
+    Future(applyScriptWithSlick(fromClasspathAsString(fileToLoad), separator, logger, database))(blockingEC)
   }
 
   /**
@@ -81,8 +83,9 @@ private[jdbc] object SchemaUtilsImpl {
   private[jdbc] def applyScript(script: String, separator: String, configKey: String, logger: Logger)(
       implicit actorSystem: ClassicActorSystemProvider): Future[Done] = {
 
+    val database = closeOnTermination(loadSlickDatabase(configKey))
     val blockingEC = actorSystem.classicSystem.dispatchers.lookup(Dispatchers.DefaultBlockingDispatcherId)
-    Future(applyScriptWithSlick(script, separator, logger, loadSlickDatabase(configKey).database))(blockingEC)
+    Future(applyScriptWithSlick(script, separator, logger, database))(blockingEC)
   }
 
   /**
@@ -209,6 +212,21 @@ private[jdbc] object SchemaUtilsImpl {
   private def loadSlickDatabase(configKey: String)(implicit actorSystem: ClassicActorSystemProvider) = {
     val journalConfig = actorSystem.classicSystem.settings.config.getConfig(configKey)
     SlickExtension(actorSystem).database(journalConfig)
+  }
+
+  /**
+   * Arranges for the database of `slickDb` to be closed when the actor system terminates, when the caller owns that
+   * database. A database that is created for this call only (the default when `use-shared-db` is not configured)
+   * would otherwise leak its connection pool, since nothing else holds on to it. The database is kept open until the
+   * actor system terminates because closing it right after the script has been applied would, for an H2 in-memory
+   * database, drop the schema that was just created.
+   */
+  private def closeOnTermination(slickDb: SlickDatabase)(
+      implicit actorSystem: ClassicActorSystemProvider): Database = {
+    if (slickDb.allowShutdown) {
+      actorSystem.classicSystem.registerOnTermination(slickDb.database.close())
+    }
+    slickDb.database
   }
 
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/JdbcDurableStateStoreProviderSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/JdbcDurableStateStoreProviderSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.jdbc.state
+
+import scala.concurrent.duration._
+
+import org.apache.pekko
+import pekko.actor.{ ActorSystem, ExtendedActorSystem }
+import pekko.persistence.jdbc.util.ConnectionPools
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class JdbcDurableStateStoreProviderSpec extends AnyWordSpecLike with Matchers with ScalaFutures {
+
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = 1.minute)
+
+  "A JdbcDurableStateStoreProvider" must {
+    "close the database it created when the actor system terminates" in {
+      val system =
+        ActorSystem("JdbcDurableStateStoreProviderSpec", ConfigFactory.load("h2-application.conf"))
+          .asInstanceOf[ExtendedActorSystem]
+      val provider = new JdbcDurableStateStoreProvider[String](system)
+
+      provider.slickDb.allowShutdown shouldBe true
+      ConnectionPools.isClosed(provider.db) shouldBe false
+
+      system.terminate().futureValue
+
+      ConnectionPools.isClosed(provider.db) shouldBe true
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/testkit/internal/SchemaUtilsImplSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/testkit/internal/SchemaUtilsImplSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.jdbc.testkit.internal
+
+import scala.concurrent.duration._
+
+import org.apache.pekko
+import pekko.Done
+import pekko.actor.ActorSystem
+import pekko.persistence.jdbc.db.SlickExtension
+import pekko.persistence.jdbc.util.{ ConnectionPools, RecordingSlickDatabaseProvider }
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.slf4j.LoggerFactory
+
+class SchemaUtilsImplSpec extends AnyWordSpecLike with Matchers with ScalaFutures {
+
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = 1.minute)
+
+  private val logger = LoggerFactory.getLogger(classOf[SchemaUtilsImplSpec])
+
+  private def withActorSystem(config: Config)(f: ActorSystem => Unit): Unit = {
+    val system = ActorSystem("SchemaUtilsImplSpec", config)
+    try f(system)
+    finally system.terminate().futureValue
+  }
+
+  "SchemaUtilsImpl" must {
+    "close the database that was created to apply the schema script when the actor system terminates" in {
+      RecordingSlickDatabaseProvider.clear()
+      val config = ConfigFactory
+        .parseString("""pekko-persistence-jdbc.database-provider-fqcn =
+            |  "org.apache.pekko.persistence.jdbc.util.RecordingSlickDatabaseProvider"""".stripMargin)
+        .withFallback(ConfigFactory.load("h2-application.conf"))
+
+      val system = ActorSystem("SchemaUtilsImplSpec", config)
+      val database =
+        try {
+          SchemaUtilsImpl.createIfNotExists("jdbc-journal", logger)(system).futureValue shouldBe Done
+
+          val databases = RecordingSlickDatabaseProvider.databases
+          databases should have size 1
+          // the database has to stay open, closing it would drop an H2 in-memory schema right after creating it
+          ConnectionPools.isClosed(databases.head) shouldBe false
+          databases.head
+        } finally system.terminate().futureValue
+
+      ConnectionPools.isClosed(database) shouldBe true
+    }
+
+    "leave a shared database open after applying the schema script" in {
+      withActorSystem(ConfigFactory.load("h2-shared-db-application.conf")) { implicit system =>
+        SchemaUtilsImpl.createIfNotExists("jdbc-journal", logger).futureValue shouldBe Done
+
+        val sharedDb = SlickExtension(system).database(system.settings.config.getConfig("jdbc-journal"))
+        sharedDb.allowShutdown shouldBe false
+        ConnectionPools.isClosed(sharedDb.database) shouldBe false
+      }
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/util/ConnectionPools.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/util/ConnectionPools.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.jdbc.util
+
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import slick.jdbc.JdbcBackend.Database
+import slick.jdbc.hikaricp.HikariCPJdbcDataSource
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[jdbc] object ConnectionPools {
+
+  /**
+   * Whether the connection pool that backs the given database has been closed. The test configurations all use the
+   * default HikariCP connection pool.
+   */
+  def isClosed(db: Database): Boolean =
+    db.source match {
+      case hikari: HikariCPJdbcDataSource => hikari.ds.isClosed
+      case other                          =>
+        throw new IllegalArgumentException(s"Expected a HikariCP backed database but got [$other]")
+    }
+}

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/util/RecordingSlickDatabaseProvider.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/util/RecordingSlickDatabaseProvider.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.jdbc.util
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+import scala.annotation.unused
+import scala.jdk.CollectionConverters._
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.annotation.InternalApi
+import pekko.persistence.jdbc.config.SlickConfiguration
+import pekko.persistence.jdbc.db.{ SlickDatabase, SlickDatabaseProvider }
+import com.typesafe.config.Config
+import slick.jdbc.JdbcBackend.Database
+
+/**
+ * INTERNAL API
+ *
+ * A [[SlickDatabaseProvider]] that behaves like the default provider, but keeps track of every database it hands out
+ * so that tests can assert on the lifecycle of those databases.
+ */
+@InternalApi
+private[jdbc] class RecordingSlickDatabaseProvider(@unused system: ActorSystem) extends SlickDatabaseProvider {
+  override def database(config: Config): SlickDatabase = {
+    val slickDatabase =
+      SlickDatabase.initializeEagerly(config, new SlickConfiguration(config.getConfig("slick")), "slick")
+    RecordingSlickDatabaseProvider.record(slickDatabase.database)
+    slickDatabase
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[jdbc] object RecordingSlickDatabaseProvider {
+  private val created = new CopyOnWriteArrayList[Database]
+
+  def record(database: Database): Unit = created.add(database)
+
+  def clear(): Unit = created.clear()
+
+  def databases: Seq[Database] = created.asScala.toList
+}

--- a/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/MigratorCloseTest.scala
+++ b/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/MigratorCloseTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.jdbc.migrator
+
+import scala.concurrent.duration._
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.persistence.jdbc.SimpleSpec
+import pekko.persistence.jdbc.db.SlickDatabase
+import pekko.persistence.jdbc.util.ConnectionPools
+import com.typesafe.config.{ Config, ConfigFactory }
+
+class MigratorCloseTest extends SimpleSpec {
+
+  implicit val pc: PatienceConfig = PatienceConfig(timeout = 1.minute)
+
+  private val config: Config = ConfigFactory.load("h2-application.conf")
+  private val profile = SlickDatabase.profile(config, "slick")
+
+  private def withActorSystem(f: ActorSystem => Unit): Unit = {
+    val system = ActorSystem("migrator-close-test", config)
+    try f(system)
+    finally system.terminate().futureValue
+  }
+
+  it should "close the database that the journal migrator opened" in withActorSystem { implicit system =>
+    val migrator = JournalMigrator(profile)
+    ConnectionPools.isClosed(migrator.journalDB) shouldBe false
+
+    migrator.close()
+
+    ConnectionPools.isClosed(migrator.journalDB) shouldBe true
+  }
+
+  it should "close the databases that the snapshot migrator opened" in withActorSystem { implicit system =>
+    val migrator = SnapshotMigrator(profile)
+    ConnectionPools.isClosed(migrator.snapshotDB) shouldBe false
+    ConnectionPools.isClosed(migrator.journalDB) shouldBe false
+
+    migrator.close()
+
+    ConnectionPools.isClosed(migrator.snapshotDB) shouldBe true
+    ConnectionPools.isClosed(migrator.journalDB) shouldBe true
+  }
+}

--- a/migrator/src/main/scala/org/apache/pekko/persistence/jdbc/migrator/JournalMigrator.scala
+++ b/migrator/src/main/scala/org/apache/pekko/persistence/jdbc/migrator/JournalMigrator.scala
@@ -20,7 +20,7 @@ import pekko.actor.ActorSystem
 import pekko.persistence.PersistentRepr
 import pekko.persistence.jdbc.PekkoSerialization
 import pekko.persistence.jdbc.config.{ JournalConfig, ReadJournalConfig }
-import pekko.persistence.jdbc.db.SlickExtension
+import pekko.persistence.jdbc.db.{ SlickDatabase, SlickExtension }
 import pekko.persistence.jdbc.journal.dao.JournalQueries
 import pekko.persistence.jdbc.journal.dao.legacy.ByteArrayJournalSerializer
 import pekko.persistence.jdbc.journal.dao.JournalTables.{ JournalPekkoSerializationRow, TagRow }
@@ -39,7 +39,7 @@ import scala.util.{ Failure, Success }
  *
  * @param system the actor system
  */
-final case class JournalMigrator(profile: JdbcProfile)(implicit system: ActorSystem) {
+final case class JournalMigrator(profile: JdbcProfile)(implicit system: ActorSystem) extends AutoCloseable {
   implicit val ec: ExecutionContextExecutor = system.dispatcher
 
   import profile.api._
@@ -53,8 +53,9 @@ final case class JournalMigrator(profile: JdbcProfile)(implicit system: ActorSys
     system.settings.config.getConfig(JournalMigrator.ReadJournalConfig))
 
   // the journal database
-  private val journalDB: JdbcBackend.Database =
-    SlickExtension(system).database(system.settings.config.getConfig(JournalMigrator.ReadJournalConfig)).database
+  private val journalSlickDb: SlickDatabase =
+    SlickExtension(system).database(system.settings.config.getConfig(JournalMigrator.ReadJournalConfig))
+  private[jdbc] val journalDB: JdbcBackend.Database = journalSlickDb.database
 
   // get an instance of the new journal queries
   private val newJournalQueries: JournalQueries =
@@ -156,6 +157,13 @@ final case class JournalMigrator(profile: JdbcProfile)(implicit system: ActorSys
       _ <- newJournalQueries.TagTable ++= tagInserts
     } yield ()
   }
+
+  /**
+   * Closes the database that was opened for this migrator. It is a no-op when the database is shared (configured with
+   * `use-shared-db`), since that one is owned by the actor system.
+   */
+  override def close(): Unit =
+    if (journalSlickDb.allowShutdown) journalDB.close()
 }
 
 case object JournalMigrator {

--- a/migrator/src/main/scala/org/apache/pekko/persistence/jdbc/migrator/SnapshotMigrator.scala
+++ b/migrator/src/main/scala/org/apache/pekko/persistence/jdbc/migrator/SnapshotMigrator.scala
@@ -19,7 +19,7 @@ import pekko.Done
 import pekko.actor.ActorSystem
 import pekko.persistence.SnapshotMetadata
 import pekko.persistence.jdbc.config.{ ReadJournalConfig, SnapshotConfig }
-import pekko.persistence.jdbc.db.SlickExtension
+import pekko.persistence.jdbc.db.{ SlickDatabase, SlickExtension }
 import pekko.persistence.jdbc.migrator.SnapshotMigrator.{ NoParallelism, SnapshotStoreConfig }
 import pekko.persistence.jdbc.query.dao.legacy.ByteArrayReadJournalDao
 import pekko.persistence.jdbc.snapshot.dao.DefaultSnapshotDao
@@ -39,7 +39,7 @@ import scala.concurrent.Future
  *
  * @param system the actor system
  */
-case class SnapshotMigrator(profile: JdbcProfile)(implicit system: ActorSystem) {
+case class SnapshotMigrator(profile: JdbcProfile)(implicit system: ActorSystem) extends AutoCloseable {
   val log: Logger = LoggerFactory.getLogger(getClass)
 
   import system.dispatcher
@@ -49,11 +49,13 @@ case class SnapshotMigrator(profile: JdbcProfile)(implicit system: ActorSystem) 
   private val readJournalConfig: ReadJournalConfig = new ReadJournalConfig(
     system.settings.config.getConfig(JournalMigrator.ReadJournalConfig))
 
-  private val snapshotDB: jdbc.JdbcBackend.Database =
-    SlickExtension(system).database(system.settings.config.getConfig(SnapshotStoreConfig)).database
+  private val snapshotSlickDb: SlickDatabase =
+    SlickExtension(system).database(system.settings.config.getConfig(SnapshotStoreConfig))
+  private[jdbc] val snapshotDB: jdbc.JdbcBackend.Database = snapshotSlickDb.database
 
-  private val journalDB: JdbcBackend.Database =
-    SlickExtension(system).database(system.settings.config.getConfig(JournalMigrator.ReadJournalConfig)).database
+  private val journalSlickDb: SlickDatabase =
+    SlickExtension(system).database(system.settings.config.getConfig(JournalMigrator.ReadJournalConfig))
+  private[jdbc] val journalDB: JdbcBackend.Database = journalSlickDb.database
 
   private val serialization: Serialization = SerializationExtension(system)
   private val queries: SnapshotQueries = new SnapshotQueries(profile, snapshotConfig.legacySnapshotTableConfiguration)
@@ -98,6 +100,15 @@ case class SnapshotMigrator(profile: JdbcProfile)(implicit system: ActorSystem) 
       defaultSnapshotDao.save(metadata, value)
     }
     .run()
+
+  /**
+   * Closes the databases that were opened for this migrator. Databases that are shared (configured with
+   * `use-shared-db`) are left alone, since those are owned by the actor system.
+   */
+  override def close(): Unit = {
+    if (snapshotSlickDb.allowShutdown) snapshotDB.close()
+    if (journalSlickDb.allowShutdown) journalDB.close()
+  }
 }
 
 case object SnapshotMigrator {


### PR DESCRIPTION
> Stacked on #608, which is the first commit here. Closing the durable state connection pool uncovered that `H2DurableStateStorePluginSchemaSpec` only passes because an earlier suite leaves a `durable_state` table in the `PUBLIC` schema of the shared H2 in-memory database. Merge #608 first, then this diff is only the second commit.

### Motivation
`DefaultSlickDatabaseProvider` creates a new `Database` (and therefore a new connection pool with its own threads) for every call that does not use `use-shared-db`. The journal, snapshot store and read journal close the database they requested, but three callers never do:

- `JdbcDurableStateStoreProvider` creates an eager database and neither closes it nor registers a shutdown hook, so its connection pool outlives the actor system.
- `SchemaUtilsImpl` creates a database for every `createIfNotExists`, `dropIfExists` and `applyScript` call and then drops the reference to it.
- `JournalMigrator` and `SnapshotMigrator` open one and two databases respectively and offer no way to close them.

### Modification
- `JdbcDurableStateStoreProvider` registers `db.close()` on actor system termination when it owns the database, the same as `JdbcReadJournal` does.
- `SchemaUtilsImpl` registers the databases it creates for closing on actor system termination. The database is deliberately not closed as soon as the script has been applied, because that would drop an H2 in-memory database together with the schema that was just created.
- `JournalMigrator` and `SnapshotMigrator` implement `AutoCloseable` and close the databases they opened.

Shared databases (`use-shared-db`) are left alone in all three cases, since those are owned by the actor system.

### Result
Connection pools that this library creates are closed again, instead of living on until the JVM exits.

### Tests
- `sbt "core/testOnly org.apache.pekko.persistence.jdbc.state.JdbcDurableStateStoreProviderSpec org.apache.pekko.persistence.jdbc.testkit.internal.SchemaUtilsImplSpec"` - passed; both new specs fail without the production change
- `sbt "migratorIntegration/testOnly org.apache.pekko.persistence.jdbc.migrator.MigratorCloseTest"` - passed
- `sbt "core/test"` - 292 passed, 1 failed: `H2ScalaCurrentEventsByTagTest` "should complete without any gaps in case events are being persisted when the query is executed". That test fails the same way on an unmodified checkout of `main` on this machine and passes on other runs, so it is pre-existing flakiness and unrelated.
- `sbt "core/mimaReportBinaryIssues"` - passed
- `scalafmt --mode diff-ref=upstream/main` - no changes

### References
None - found while reviewing the main sources for resource leaks
