### PR TITLE
Use the configured schema in the H2 durable state sequence lookup

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/state/SequenceNextValUpdater.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/state/SequenceNextValUpdater.scala
@@ -39,11 +39,14 @@ import slick.sql.SqlStreamingAction
 
   // H2 dependent (based on https://www.h2database.com/html/systemtables.html)
   def getSequenceNextValueExpr() = {
+    // H2 stores unquoted identifiers upper case unless the database is created with DATABASE_TO_UPPER=false,
+    // so the configured schema name is compared case insensitively
+    val schemaName = durableStateTableCfg.schemaName.getOrElse("PUBLIC")
     sql"""SELECT COLUMN_DEFAULT
           FROM INFORMATION_SCHEMA.COLUMNS
           WHERE TABLE_NAME = '#${durableStateTableCfg.tableName}'
             AND COLUMN_NAME = '#${durableStateTableCfg.columnNames.globalOffset}'
-            AND TABLE_SCHEMA = 'PUBLIC'""".as[String]
+            AND UPPER(TABLE_SCHEMA) = UPPER('#$schemaName')""".as[String]
   }
 }
 


### PR DESCRIPTION
### Motivation
`H2SequenceNextValUpdater` looks up the column default that provides the next global offset with `TABLE_SCHEMA = 'PUBLIC'` hard coded, so it finds nothing when `jdbc-durable-state-store.tables.durable_state.schemaName` points at another schema. `upsertObject` then fails with `NoSuchElementException: empty.head`.

`H2DurableStateStorePluginSchemaSpec` covers exactly that configuration and fails when it is run on its own:

```
sbt "core/testOnly org.apache.pekko.persistence.jdbc.state.scaladsl.H2DurableStateStorePluginSchemaSpec"
[info] - must persist states successfully *** FAILED ***
[info]   The future returned an exception of type: java.util.NoSuchElementException, with message: empty.head.
```

It only passes as part of the full core test run because an earlier suite leaves a `durable_state` table behind in the `PUBLIC` schema of the shared H2 in-memory database, and that table happens to answer the query.

### Modification
Use the configured schema name, falling back to `PUBLIC`, and compare it case insensitively, because H2 upper cases unquoted identifiers unless the database was created with `DATABASE_TO_UPPER=false`.

### Result
Durable state works on H2 with a schema other than `PUBLIC`.

### Tests
- `sbt "core/testOnly org.apache.pekko.persistence.jdbc.state.scaladsl.H2DurableStateStorePluginSchemaSpec"` - passed; the same command fails on `main`. That existing spec is the directional test for this fix.
- `sbt "core/testOnly *DurableState*"` - passed
- `scalafmt --mode diff-ref=upstream/main` - no changes

### References
None - found while making the durable state store close its connection pool (#606)
