### PR TITLE
Stop a timed-out migrator test from leaking into the next one

### DIFF
--- a/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/JournalMigratorTest.scala
+++ b/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/JournalMigratorTest.scala
@@ -43,8 +43,9 @@ abstract class JournalMigratorTest(configName: String) extends MigratorSpec(conf
     withActorSystem { implicit systemNew =>
       withReadJournal { implicit readJournal =>
         countJournal().futureValue shouldBe 0 // before migration
+        // migrate exactly once: retrying while a migration is still in flight duplicates rows
+        JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
         eventually {
-          JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
           countJournal().futureValue shouldBe 9 // after migration
         }
         withTestActors() { (actorB1, actorB2, actorB3) =>
@@ -79,8 +80,9 @@ abstract class JournalMigratorTest(configName: String) extends MigratorSpec(conf
     withActorSystem { implicit systemNew =>
       withReadJournal { implicit readJournal =>
         countJournal().futureValue shouldBe 0 // before migration
+        // migrate exactly once: retrying while a migration is still in flight duplicates rows
+        JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
         eventually {
-          JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
           countJournal().futureValue shouldBe 3000 // after migration
         }
         val allEvents: Seq[Seq[AccountEvent]] = events().futureValue
@@ -117,8 +119,9 @@ abstract class JournalMigratorTest(configName: String) extends MigratorSpec(conf
     withActorSystem { implicit systemNew =>
       withReadJournal { implicit readJournal =>
         countJournal().futureValue shouldBe 0 // before migration
+        // migrate exactly once: retrying while a migration is still in flight duplicates rows
+        JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
         eventually {
-          JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
           countJournal().futureValue shouldBe 3000 // after migration
         }
         val evenEvents: Seq[AccountEvent] = eventsByTag(MigratorSpec.Even).futureValue

--- a/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/MigratorSpec.scala
+++ b/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/MigratorSpec.scala
@@ -40,7 +40,7 @@ abstract class MigratorSpec(val config: Config) extends SimpleSpec with BeforeAn
   // The db is initialized in the before and after each bocks
   var dbOpt: Option[Database] = None
 
-  implicit val pc: PatienceConfig = PatienceConfig(timeout = 10.seconds)
+  implicit val pc: PatienceConfig = PatienceConfig(timeout = 30.seconds)
   implicit val timeout: Timeout = Timeout(1.minute)
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
@@ -118,8 +118,10 @@ abstract class MigratorSpec(val config: Config) extends SimpleSpec with BeforeAn
 
   def withActorSystem(f: ActorSystem => Unit): Unit = {
     implicit val system: ActorSystem = ActorSystem("migrator-test", config)
-    f(system)
-    system.terminate().futureValue
+    // terminate in a finally block: a failing test must not leak a running migration
+    // stream into the next test, which recreates the tables in its beforeEach
+    try f(system)
+    finally system.terminate().futureValue
   }
 
   def withLegacyActorSystem(f: ActorSystem => Unit): Unit = {
@@ -137,8 +139,8 @@ abstract class MigratorSpec(val config: Config) extends SimpleSpec with BeforeAn
     }
 
     implicit val system: ActorSystem = ActorSystem("migrator-test", legacyDAOConfig)
-    f(system)
-    system.terminate().futureValue
+    try f(system)
+    finally system.terminate().futureValue
   }
 
   def withReadJournal(f: JdbcReadJournal => Unit)(implicit system: ActorSystem): Unit = {

--- a/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/MigratorSpecFixtureTest.scala
+++ b/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/MigratorSpecFixtureTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.jdbc.migrator
+
+import org.apache.pekko.actor.ActorSystem
+
+/**
+ * Checks the actor system lifecycle contract of the [[MigratorSpec]] fixtures. A failing test body must not leak a
+ * running actor system, because the migration stream it still owns keeps writing into the journal tables that the next
+ * test recreates in its `beforeEach`.
+ *
+ * No database is required: the fixtures are exercised without starting any persistent actor.
+ */
+class MigratorSpecFixtureTest extends MigratorSpec("h2-application.conf") {
+
+  private def assertTerminatesWhenBodyFails(fixture: (ActorSystem => Unit) => Unit): Unit = {
+    var captured: Option[ActorSystem] = None
+    val thrown = intercept[RuntimeException] {
+      fixture { system =>
+        captured = Some(system)
+        throw new RuntimeException("boom")
+      }
+    }
+    thrown.getMessage shouldBe "boom"
+    val system = captured.getOrElse(fail("the fixture never ran the test body"))
+    system.whenTerminated.futureValue
+  }
+
+  it should "terminate the actor system when the test body fails" in {
+    assertTerminatesWhenBodyFails(withActorSystem)
+  }
+
+  it should "terminate the legacy actor system when the test body fails" in {
+    assertTerminatesWhenBodyFails(withLegacyActorSystem)
+  }
+}

--- a/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/SnapshotMigratorTest.scala
+++ b/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/SnapshotMigratorTest.scala
@@ -40,9 +40,10 @@ abstract class SnapshotMigratorTest(configName: String) extends MigratorSpec(con
     } // legacy persistence
     withActorSystem { implicit systemNew =>
       withReadJournal { implicit readJournal =>
+        countJournal().futureValue shouldBe 0 // before migration
+        // migrate exactly once: a retry would race with a migration that is still in flight
+        SnapshotMigrator(SlickDatabase.profile(config, "slick")).migrateAll().futureValue shouldBe Done
         eventually {
-          countJournal().futureValue shouldBe 0 // before migration
-          SnapshotMigrator(SlickDatabase.profile(config, "slick")).migrateAll().futureValue shouldBe Done
           countJournal().futureValue shouldBe 0 // after migration
         }
         withTestActors() { (actorB1, actorB2, actorB3) =>


### PR DESCRIPTION
Motivation:
The SqlServer migrator integration tests failed on main in [run 34093026922](https://github.com/apache/pekko-persistence-jdbc/actions/runs/34093026922/job/101650378069) when the runner was slow:

```
- should migrate the event journal preserving the order of events *** FAILED *** (18s)
    The code passed to eventually never returned normally. Attempted 1 times over 10.007s.
    Last failure: A timeout occurred waiting for a future to complete. Waited 10000000000 ns.
- should migrate the event journal preserving tags *** FAILED *** (8.9s)
    262 was not equal to 0
```

The commit under test (#607) does not touch journal migration and the same branch passed this job on its PR run, so this is a timing flake rather than a regression. There is no open issue tracking it.

The second failure is fallout from the first. `withActorSystem` called `system.terminate()` after the test body rather than in a `finally`, so a failing body left the actor system running. Its in-flight migration stream kept writing while the next test recreated the tables in its `beforeEach`, and those 262 rows landed in the fresh table. One slow migration therefore produced two failures.

The 10 second budget was also too tight. Comparing against the last green run of the same job (33907316903):

| phase | green run | failing run |
| --- | --- | --- |
| legacy write phase (3000 events) | 6.3s | 8.4s |
| migrate + verify phase | 7.3s | hit the 10.0s cap |
| test total | 13.6s | 18.4s (failed) |

Wrapping the migration in `eventually` does not help either: the first `futureValue` consumes the whole patience window, so `eventually` never gets a second attempt, and a retry that did fire while the first migration was still running would race with it. `SnapshotMigratorTest` had the same shape, so it is fixed here too.

Modification:
- Terminate the actor system in a `finally` block in both `withActorSystem` and `withLegacyActorSystem`.
- Raise the migrator `PatienceConfig` timeout from 10 to 30 seconds.
- Call the migration once in `JournalMigratorTest` and `SnapshotMigratorTest`, keeping `eventually` only around the row-count assertion that follows it.
- Add `MigratorSpecFixtureTest`, which asserts that both fixtures terminate the actor system when the test body throws. It needs no database, so it runs anywhere.

Result:
A slow migration no longer corrupts the following test, and a migration is never run concurrently with itself.

Tests:
- `sbt "migratorIntegration/Test/testOnly org.apache.pekko.persistence.jdbc.migrator.H2JournalMigratorTest org.apache.pekko.persistence.jdbc.migrator.H2SnapshotMigratorTest org.apache.pekko.persistence.jdbc.migrator.MigratorSpecFixtureTest"` - 6 succeeded, 0 failed
- `MigratorSpecFixtureTest` with the `finally` reverted - both tests fail (the actor system never terminates), confirming the fixture leak
- `sbt "migratorIntegration/scalafmtAll"` and `sbt "migratorIntegration/headerCreateAll"` - run, no further changes
- The SqlServer, Postgres, MySQL and Oracle migrator tests need running database servers and were left to CI

References:
Refs https://github.com/apache/pekko-persistence-jdbc/actions/runs/34093026922/job/101650378069, Refs #192
