### PR TITLE
Switch to ojdbc11 from ojdbc8

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
     "com.mysql" % "mysql-connector-j" % "26.7.0",
     "org.mariadb.jdbc" % "mariadb-java-client" % "3.5.10",
     "com.microsoft.sqlserver" % "mssql-jdbc" % "13.4.0.jre11",
-    "com.oracle.database.jdbc" % "ojdbc8" % "23.26.2.0.0")
+    "com.oracle.database.jdbc" % "ojdbc11" % "23.26.2.0.0")
 
   val Libraries: Seq[ModuleID] = Seq(
     "com.typesafe.slick" %% "slick" % SlickVersion,


### PR DESCRIPTION
We're on java 17 in this project, so we can switch to ojdbc11. https://mvnrepository.com/artifact/com.oracle.database.jdbc states "Oracle JDBC Driver compatible with JDK11, JDK17, JDK19, and JDK21" while ojdbc8 states "Oracle JDBC Driver compatible with JDK8 and JDK11".