### PR TITLE
Defer debug log message construction to the logging backend

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/testkit/internal/SchemaUtilsImpl.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/testkit/internal/SchemaUtilsImpl.scala
@@ -142,12 +142,12 @@ private[jdbc] object SchemaUtilsImpl {
       for {
         line <- lines if line.nonEmpty
       } yield {
-        logger.debug(s"applying DDL: $line")
+        logger.debug("applying DDL: {}", line)
 
         try stmt.executeUpdate(line)
         catch {
           case t: java.sql.SQLException =>
-            logger.debug(s"Exception while applying SQL script", t)
+            logger.debug("Exception while applying SQL script", t)
         }
       }
     }

--- a/migrator/src/main/scala/org/apache/pekko/persistence/jdbc/migrator/JournalMigrator.scala
+++ b/migrator/src/main/scala/org/apache/pekko/persistence/jdbc/migrator/JournalMigrator.scala
@@ -93,7 +93,10 @@ final case class JournalMigrator(profile: JdbcProfile)(implicit system: ActorSys
       val stmt: DBIO[Unit] = records
         // get all the sql statements for this record as an option
         .map { case (newRepr, newTags) =>
-          log.debug(s"migrating event for PersistenceID: ${newRepr.persistenceId} with tags ${newTags.mkString(",")}")
+          if (log.isDebugEnabled()) {
+            log.debug("migrating event for PersistenceID: {} with tags {}", newRepr.persistenceId,
+              newTags.mkString(","))
+          }
           writeJournalRowsStatements(newRepr, newTags)
         }
         // reduce to 1 statement

--- a/migrator/src/main/scala/org/apache/pekko/persistence/jdbc/migrator/SnapshotMigrator.scala
+++ b/migrator/src/main/scala/org/apache/pekko/persistence/jdbc/migrator/SnapshotMigrator.scala
@@ -79,7 +79,7 @@ case class SnapshotMigrator(profile: JdbcProfile)(implicit system: ActorSystem) 
         // let us fetch the latest snapshot for each persistenceId
         snapshotDB.run(queries.selectLatestByPersistenceId(persistenceId).result).map { rows =>
           rows.headOption.map(toSnapshotData).map { case (metadata, value) =>
-            log.debug(s"migrating snapshot for ${metadata.toString}")
+            log.debug("migrating snapshot for {}", metadata)
             defaultSnapshotDao.save(metadata, value)
           }
         }
@@ -94,7 +94,7 @@ case class SnapshotMigrator(profile: JdbcProfile)(implicit system: ActorSystem) 
     .fromPublisher(snapshotDB.stream(queries.SnapshotTable.result))
     .mapAsync(NoParallelism) { record =>
       val (metadata, value) = toSnapshotData(record)
-      log.debug(s"migrating snapshot for ${metadata.toString}")
+      log.debug("migrating snapshot for {}", metadata)
       defaultSnapshotDao.save(metadata, value)
     }
     .run()


### PR DESCRIPTION
### Motivation
Several debug calls built their message eagerly with string interpolation, so the interpolation ran even when debug logging was disabled. In `JournalMigrator` that also meant a `mkString` over the tag set for every migrated event.

### Modification
Replace interpolation with `{}` placeholders and pass the values as logging arguments, and guard the `JournalMigrator` call — whose argument needs a `mkString` — with `isDebugEnabled`.

### Result
No message or tag-set string is built unless the backend will emit the line. Logging output is unchanged.

### Tests
- `scalafmt` on the three changed files / no reformatting needed
- No test added or run: the change only moves message formatting into the logging backend and emits identical output; compilation and the existing suites are covered by CI

### References
None - follow-up cleanup on the debug logging in these three files
