### PR TITLE
Remove redundant Scala 2.12-era immutable.Seq imports

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
@@ -31,7 +31,6 @@ import com.typesafe.config.Config
 import slick.jdbc.JdbcProfile
 import slick.jdbc.JdbcBackend._
 
-import scala.collection.immutable._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
 import pekko.pattern.pipe

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/BaseDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/BaseDao.scala
@@ -20,7 +20,6 @@ import pekko.persistence.jdbc.config.BaseDaoConfig
 import pekko.stream.scaladsl.{ Keep, Sink, Source }
 import pekko.stream.{ BoundedSourceQueue, Materializer, QueueOfferResult }
 
-import scala.collection.immutable.{ Seq, Vector }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 
 // Shared with the legacy DAO

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/DefaultJournalDao.scala
@@ -27,8 +27,6 @@ import pekko.stream.scaladsl.Source
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.JdbcProfile
 
-import scala.collection.immutable
-import scala.collection.immutable.{ Nil, Seq }
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
 
@@ -50,7 +48,7 @@ class DefaultJournalDao(
 
   override def baseDaoConfig: BaseDaoConfig = journalConfig.daoConfig
 
-  override def writeJournalRows(xs: immutable.Seq[(JournalPekkoSerializationRow, Set[String])]): Future[Unit] = {
+  override def writeJournalRows(xs: Seq[(JournalPekkoSerializationRow, Set[String])]): Future[Unit] = {
     db.run(queries.writeJournalRows(xs).transactionally).map(_ => ())(ExecutionContext.parasitic)
   }
 
@@ -76,7 +74,7 @@ class DefaultJournalDao(
     } yield maybeHighestSeqNo.getOrElse(0L)
   }
 
-  override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
 
     def serializeAtomicWrite(aw: AtomicWrite): Try[Seq[(JournalPekkoSerializationRow, Set[String])]] = {
       Try(aw.payload.map(serialize))

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalDao.scala
@@ -15,7 +15,6 @@
 package org.apache.pekko.persistence.jdbc.journal.dao
 
 import org.apache.pekko.persistence.AtomicWrite
-import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.util.Try
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.JdbcProfile
 
-import scala.collection.immutable.{ Nil, Seq }
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalSerializer.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalSerializer.scala
@@ -20,7 +20,6 @@ import pekko.persistence.PersistentRepr
 import pekko.persistence.jdbc.serialization.FlowPersistentReprSerializer
 import pekko.serialization.Serialization
 
-import scala.collection.immutable._
 import scala.util.Try
 
 class ByteArrayJournalSerializer(serialization: Serialization, separator: String)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/package.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/package.scala
@@ -15,7 +15,6 @@
 package org.apache.pekko.persistence.jdbc.journal.dao
 
 import scala.annotation.nowarn
-import scala.collection.immutable.Set
 
 package object legacy {
   @nowarn("msg=it is not recommended to define classes/objects inside of package objects")

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/dao/ReadJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/dao/ReadJournalDao.scala
@@ -20,7 +20,6 @@ import pekko.persistence.PersistentRepr
 import pekko.persistence.jdbc.journal.dao.JournalDaoWithReadMessages
 import pekko.stream.scaladsl.Source
 
-import scala.collection.immutable.Set
 import scala.concurrent.Future
 import scala.util.Try
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/dao/legacy/ByteArrayReadJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/dao/legacy/ByteArrayReadJournalDao.scala
@@ -29,7 +29,6 @@ import pekko.stream.scaladsl.{ Flow, Source }
 import slick.jdbc.JdbcBackend._
 import slick.jdbc.{ GetResult, JdbcProfile }
 
-import scala.collection.immutable._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -34,7 +34,6 @@ import com.typesafe.config.Config
 import slick.jdbc.JdbcBackend._
 import slick.jdbc.JdbcProfile
 
-import scala.collection.immutable._
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/serialization/PersistentReprSerializer.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/serialization/PersistentReprSerializer.scala
@@ -20,7 +20,6 @@ import pekko.persistence.jdbc.util.TrySeq
 import pekko.persistence.journal.Tagged
 import pekko.persistence.{ AtomicWrite, PersistentRepr }
 import pekko.stream.scaladsl.Flow
-import scala.collection.immutable._
 
 import scala.util.Try
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/snapshot/JdbcSnapshotStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/snapshot/JdbcSnapshotStore.scala
@@ -27,7 +27,6 @@ import com.typesafe.config.Config
 import slick.jdbc.JdbcProfile
 import slick.jdbc.JdbcBackend._
 
-import scala.collection.immutable._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/util/TrySeq.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/util/TrySeq.scala
@@ -15,7 +15,6 @@
 package org.apache.pekko.persistence.jdbc.util
 
 import scala.annotation.nowarn
-import scala.collection.immutable._
 import scala.util.{ Failure, Success, Try }
 
 object TrySeq {

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/JdbcAsyncWriteJournalShutdownTest.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/JdbcAsyncWriteJournalShutdownTest.scala
@@ -19,7 +19,6 @@ package org.apache.pekko.persistence.jdbc.journal
 
 import java.util.concurrent.CopyOnWriteArrayList
 
-import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/dao/BaseDaoSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/dao/BaseDaoSpec.scala
@@ -19,7 +19,6 @@ package org.apache.pekko.persistence.jdbc.journal.dao
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
-import scala.collection.immutable.Seq
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/dao/LimitWindowingStreamTest.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/dao/LimitWindowingStreamTest.scala
@@ -30,7 +30,6 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.slf4j.LoggerFactory
 
 import java.util.UUID
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
 
@@ -65,7 +64,7 @@ abstract class LimitWindowingStreamTest(configFile: String)
             val start = end - (eventsPerBatch - 1)
             log.info(s"batch $i - events from $start to $end")
             val atomicWrites = (start to end).map { j =>
-              AtomicWrite(immutable.Seq(PersistentRepr(payload, j, persistenceId, writerUuid = writerUuid)))
+              AtomicWrite(Seq(PersistentRepr(payload, j, persistenceId, writerUuid = writerUuid)))
             }
             dao.asyncWriteMessages(atomicWrites).map(_ => i)
           }

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/dao/MessagesWithBatchDatabaseContractTest.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/dao/MessagesWithBatchDatabaseContractTest.scala
@@ -27,7 +27,6 @@ import pekko.stream.{ Materializer, SystemMaterializer }
 
 import java.io.NotSerializableException
 import java.util.UUID
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -136,7 +135,7 @@ abstract class MessagesWithBatchDatabaseContractTest(configFile: String) extends
     val writerUuid = UUID.randomUUID().toString
     val payload = Array.fill(8)('a'.toByte)
     val writes = (1 to count).map { sequenceNr =>
-      AtomicWrite(immutable.Seq(PersistentRepr(payload, sequenceNr, persistenceId, writerUuid = writerUuid)))
+      AtomicWrite(Seq(PersistentRepr(payload, sequenceNr, persistenceId, writerUuid = writerUuid)))
     }
     dao.asyncWriteMessages(writes).futureValue
   }

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/dao/TrySeqTest.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/dao/TrySeqTest.scala
@@ -18,7 +18,6 @@ import org.apache.pekko
 import pekko.persistence.jdbc.util.TrySeq
 import pekko.persistence.jdbc.SimpleSpec
 
-import scala.collection.immutable._
 import scala.util.{ Failure, Success }
 
 class TrySeqTest extends SimpleSpec {

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalSerializerTest.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalSerializerTest.scala
@@ -17,8 +17,6 @@ package journal.dao.legacy
 
 import org.apache.pekko.persistence.{ AtomicWrite, PersistentRepr }
 
-import scala.collection.immutable._
-
 class ByteArrayJournalSerializerTest extends SharedActorSystemTestSpec() {
   it should "serialize a serializable message and indicate whether or not the serialization succeeded" in {
     val serializer = new ByteArrayJournalSerializer(serialization, ",")

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
@@ -27,7 +27,6 @@ import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.slf4j.LoggerFactory
 
-import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
@@ -84,7 +83,7 @@ abstract class JournalDaoStreamMessagesMemoryTest(configFile: String)
             val start = end - (eventsPerBatch - 1)
             log.info(s"batch $i - events from $start to $end")
             val atomicWrites = (start to end).map { j =>
-              AtomicWrite(immutable.Seq(PersistentRepr(payload, j, persistenceId, writerUuid = writerUuid)))
+              AtomicWrite(Seq(PersistentRepr(payload, j, persistenceId, writerUuid = writerUuid)))
             }
             dao.asyncWriteMessages(atomicWrites).map(_ => i)
           }

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/QueryTestSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/QueryTestSpec.scala
@@ -38,7 +38,6 @@ import com.typesafe.config.ConfigValue
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.JdbcProfile
 
-import scala.collection.immutable
 import scala.concurrent.duration.{ FiniteDuration, _ }
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
@@ -347,7 +346,7 @@ abstract class QueryTestSpec(config: String, configOverrides: Map[String, Config
 
   def withDao(f: JournalDao => Unit)(implicit system: ActorSystem, ec: ExecutionContext, mat: Materializer): Unit = {
     val fqcn: String = journalConfig.pluginConfig.dao
-    val args: immutable.Seq[(Class[?], AnyRef)] = immutable.Seq(
+    val args: Seq[(Class[?], AnyRef)] = Seq(
       (classOf[Database], db), (classOf[JdbcProfile], profile), (classOf[JournalConfig], journalConfig),
       (classOf[Serialization], SerializationExtension(system)), (classOf[ExecutionContext], ec),
       (classOf[Materializer], mat))

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
@@ -78,7 +78,7 @@ class TestProbeReadJournalDao(val probe: TestProbe) extends ReadJournalDao {
    * @return A Source of journal event sequence numbers (corresponding to the Ordering column)
    */
   override def journalSequence(offset: Long, limit: Long): Source[Long, NotUsed] = {
-    val f = probe.ref.ask(JournalSequence(offset, limit)).mapTo[scala.collection.immutable.Seq[Long]]
+    val f = probe.ref.ask(JournalSequence(offset, limit)).mapTo[Seq[Long]]
     Source.future(f).mapConcat(identity)
   }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/TestProbeDurableStateStoreQuery.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/TestProbeDurableStateStoreQuery.scala
@@ -52,7 +52,7 @@ class TestProbeDurableStateStoreQuery(
   override def stateStoreStateInfo(offset: Long, limit: Long): Source[(String, Long, Long), NotUsed] = {
     val f = probe.ref
       .ask(TestProbeDurableStateStoreQuery.StateInfoSequence(offset, limit))
-      .mapTo[scala.collection.immutable.Seq[DurableStateSequenceActor.VisitedElement]]
+      .mapTo[Seq[DurableStateSequenceActor.VisitedElement]]
 
     Source.future(f).mapConcat(e => e.map(x => (x.pid, x.offset, x.revision)))
   }


### PR DESCRIPTION
### Motivation
Since Scala 2.13, `scala.Seq` is a type alias for `scala.collection.immutable.Seq`, and `Set`, `Vector`, `Nil` and friends in the `scala` package already refer to the immutable collections. The `scala.collection.immutable` imports and `immutable.Seq` qualifiers carried over from the Scala 2.12 days are therefore redundant now that this project only builds on 2.13 and 3.

This is the pekko-persistence-jdbc counterpart of apache/pekko#3539. Of the idioms cleaned up there, only the `immutable.Seq` one exists in this repo — there are no `WrappedArray`, `filterKeys`/`mapValues`, `Either` projection, `Stream` or `.toIterator` uses to touch.

### Modification
- Drop the now-unused `scala.collection.immutable` imports (`immutable._`, `immutable.Seq`, `immutable.Set`, `immutable.{ Nil, Seq }`, `immutable.{ Seq, Vector }`) across 23 files.
- Replace `immutable.Seq` / `scala.collection.immutable.Seq` with plain `Seq`.
- `MissingElements` keeps its `immutable.NumericRange` import since `NumericRange` is not aliased in `scala._`.

`scala.Seq` erases to the same class, so the binary shape is unchanged. The one place where dropping `immutable._` changes a resolved type is a local `def next(id: String): Iterable[String]` inside `JdbcReadJournal.persistenceIds` (now `collection.Iterable` instead of `immutable.Iterable`), which is a closure-local helper passed to `statefulMapConcat` and not part of any API.

### Result
No remaining Scala 2.12 collection idioms in main or test sources.

### Tests
- native `scalafmt --mode diff-ref=upstream/main`
- `sbt "+core/Test/compile"` on Scala 2.13.18, 3.3.8 and 3.9.0
- `sbt core/mimaReportBinaryIssues` passes (with `mimaReportSignatureProblems := true`)
- `sbt "core/Test/testOnly ...TrySeqTest ...BaseDaoSpec ...H2LimitWindowingStreamTest ...JdbcAsyncWriteJournalShutdownTest ...H2ScalaCurrentPersistenceIdsTest ...ByteArrayJournalSerializerTest"`: 16 tests, all passed against H2
- `git diff --check` clean
- No new directional test: this is a pure import/alias cleanup with no behavior change; the existing specs covering the touched code were run above.

### References
Refs apache/pekko#3539
